### PR TITLE
Actions to sign in with custom token or email and password

### DIFF
--- a/src/hooks/useFirebaseWithBridge/index.js
+++ b/src/hooks/useFirebaseWithBridge/index.js
@@ -107,6 +107,16 @@ function useFirebaseWithBridge() {
           auth.signOut();
         }
       },
+      signInWithCustomToken: ({ token }) => {
+        if (auth && token) {
+          auth.signInWithCustomToken(token);
+        }
+      },
+      signInWithEmailAndPassword: ({ email, password }) => {
+        if (auth && email && password) {
+          auth.signInWithEmailAndPassword(email, password);
+        }
+      },
       change: ({ data, function: func, value }) => {
         const { currentUser } = auth;
 

--- a/src/json/session/pandasuite.json
+++ b/src/json/session/pandasuite.json
@@ -67,6 +67,51 @@
       }
     },
     {
+      "id": "signInWithCustomToken",
+      "name": "Sign In with Custom Token",
+      "locale_name": {
+        "fr_FR": "Se connecter avec un jeton personnalisé"
+      },
+      "params": [
+        {
+          "id": "token",
+          "name": "Token",
+          "locale_name": {
+            "fr_FR": "Jeton"
+          },
+          "type": "String",
+          "value": ""
+        }
+      ]
+    },
+    {
+      "id": "signInWithEmailAndPassword",
+      "name": "Sign In with Email and Password",
+      "locale_name": {
+        "fr_FR": "Se connecter avec email et mot de passe"
+      },
+      "params": [
+        {
+          "id": "email",
+          "name": "Email",
+          "locale_name": {
+            "fr_FR": "Email"
+          },
+          "type": "String",
+          "value": ""
+        },
+        {
+          "id": "password",
+          "name": "Password",
+          "locale_name": {
+            "fr_FR": "Mot de passe"
+          },
+          "type": "String",
+          "value": ""
+        }
+      ]
+    },
+    {
       "id": "change",
       "name": "Modify the data",
       "locale_name": {


### PR DESCRIPTION
Added 2 actions : signInWithCustomToken & signInWithEmailAndPassword, to reflect the firebase auth api and enable other ways of logging in.