### PR TITLE
feat: Firestore-native optimistic writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ yarn-error.log*
 /public/pandasuite.json
 .omx/
 .omc/
+# Firebase emulator artifacts
+firestore-debug.log
+firebase-debug.log

--- a/docs/testing/indexeddb-safari-workaround.md
+++ b/docs/testing/indexeddb-safari-workaround.md
@@ -1,0 +1,81 @@
+# IndexedDB Safari workaround — characterization
+
+Before Task 11, two copies of `fixIndexDbBug()` ran on normal startup paths:
+
+- `src/components/session/SessionRuntime.jsx` — on every sign-in (guarded).
+- `src/pages/Home/index.jsx` — on every Home mount (unguarded).
+
+Both deleted `firestore/*` IndexedDB databases when `openDB(...).getAll('owner')`
+does not settle within 200 ms. On a slow device this deletes **pending offline
+writes**. The optimistic-writes design forbids deletion on any normal startup
+path (spec: Persistence).
+
+## Suspected original failure
+
+Safari (including PandaSuite WebViews) could leave the Firestore IndexedDB in a
+state where opening it hangs forever, blocking all Firestore startup. The
+workaround probed the `owner` object store and deleted the database when the
+probe hung.
+
+## Protocol
+
+Run each scenario on: macOS Safari (current), iOS Safari (current), one
+supported PandaSuite iOS WebView, one supported Android WebView.
+
+1. **Baseline**: `yarn start:session`, sign in, write data, reload. Expect: no
+   hang, data present.
+2. **Interrupted first open**: sign in, then kill the tab during initial load
+   (within ~1s). Reopen. Expect to characterize: does Firestore startup hang?
+3. **Multi-tab contention**: open two tabs, sign in in both, reload both
+   simultaneously ×5. Expect to characterize: any hang or
+   `failed-precondition`?
+4. **Private mode**: repeat baseline in private browsing. Expect:
+   `enablePersistence` rejects, memory fallback, page still works.
+5. **Pending offline writes across reload**: go offline (DevTools), perform 3
+   change actions, reload while offline, reconnect. Expect: writes submit after
+   reconnection. **This is the scenario the old workaround could destroy.**
+
+For any hang: capture the console, `indexedDB.databases()` output, and whether
+deleting `firestore/*` manually unblocks the next load.
+
+## Results
+
+| Scenario | Platform | Result | Hang reproduced? |
+| --- | --- | --- | --- |
+| (fill during execution) | | | |
+
+## Decision
+
+- This branch performs no automatic IndexedDB deletion or recovery.
+- If persistence is rejected, the app warns and continues with the Firestore
+  memory fallback.
+- `onChangeError` reports writes submitted by the current page. After a reload,
+  Firestore restores pending writes and reconciles rejected mutations through
+  snapshots, but it cannot restore the originating JavaScript callbacks.
+- If real Safari/WebView characterization reproduces the historical hang,
+  release is blocked until a separate pre-consumer recovery design is
+  implemented and verified on the failing platform (spec: Persistence).
+
+# Post-implementation browser/WebView verification
+
+Run with `yarn start:session` (Chrome DevTools for offline simulation), then on
+Safari and one supported PandaSuite WebView per platform. All items must pass
+before release.
+
+- [ ] A `change` action updates the PandaSuite queryable **before** server
+      acknowledgement (throttle network to Slow 3G; UI reflects the change
+      immediately).
+- [ ] With DevTools offline: 3 change actions on the same document emit **no**
+      `onChangeError`, and after reconnection the server document reflects all
+      3 in submission order.
+- [ ] Reload while offline with persistent cache: pending writes survive the
+      reload and submit after reconnection.
+- [ ] Two tabs signed in as the same user see a coherent local view
+      (`synchronizeTabs`).
+- [ ] Private-browsing (persistence rejected): one degraded-mode `console.warn`,
+      no `onChangeError`, live writes still work.
+- [ ] DevTools → Application → IndexedDB: after sign-in and navigation to Home,
+      the `firestore/*` database is never deleted (normal startup performs no
+      recovery).
+- [ ] Safari + WebViews: pending offline writes survive a reload (the scenario
+      the old workaround destroyed).

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "5.2.4",
   "homepage": "./",
   "private": true,
+  "resolutions": {
+    "@google-cloud/cloud-sql-connector": "1.8.2",
+    "re2": "1.21.4",
+    "universal-analytics": "0.5.3"
+  },
   "dependencies": {
     "@beingenious/jsoneditor": "^0.14.8",
     "@beingenious/jsonpointer": "^3.6.2",
@@ -30,6 +35,7 @@
     "start:auth": "vite --open /auth.html",
     "start:session": "vite --open /session.html",
     "test": "node --test tests/*.test.mjs",
+    "test:emulator": "firebase emulators:exec --config tests/emulator/firebase.json --only firestore --project demo-panda-optimistic \"node --test --test-concurrency=1 tests/emulator/*.test.mjs\"",
     "build:auth": "cross-env VITE_APP_TARGET=auth vite build --outDir build-auth --emptyOutDir",
     "build:session": "cross-env VITE_APP_TARGET=session vite build --outDir build-session --emptyOutDir && mv build-session/session.html build-session/index.html",
     "package:auth": "cp src/json/auth/pandasuite.json build-auth/pandasuite.json && cd build-auth && zip -r -X ../pandasuite-auth-component.zip *",
@@ -70,6 +76,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.18.3",
     "eslint-plugin-react-hooks": "^1.7.0",
+    "firebase-tools": "^13",
     "postcss": "^7",
     "prettier": "^3.2.5",
     "release-it": "^13.0.1",

--- a/src/components/session/SessionRuntime.jsx
+++ b/src/components/session/SessionRuntime.jsx
@@ -1,46 +1,8 @@
 import { useContext, useEffect } from 'react';
 import PandaBridge from 'pandasuite-bridge';
-import { deleteDB, openDB } from 'idb';
-import { find } from 'lodash';
 
 import FirebaseBridgeContext from '../../FirebaseBridgeContext';
 import { toQueryableShape } from '../../hooks/useFirebaseWithBridge/collectionStorageAdapter.mjs';
-
-async function fixIndexDbBug() {
-  if (
-    typeof window === 'undefined' ||
-    !window.indexedDB ||
-    typeof window.indexedDB.databases !== 'function'
-  ) {
-    return;
-  }
-
-  const databases = await window.indexedDB.databases();
-  const firestoreDb = find(databases, (db) =>
-    db?.name?.startsWith('firestore/'),
-  );
-
-  if (!firestoreDb) {
-    return;
-  }
-
-  const timeOut = setTimeout(async () => {
-    try {
-      await deleteDB(firestoreDb.name);
-    } catch (error) {
-      console.error('IndexedDB cleanup failed', error);
-    }
-  }, 200);
-
-  try {
-    const db = await openDB(firestoreDb.name);
-    await db.getAll('owner');
-    clearTimeout(timeOut);
-    db.close();
-  } catch (error) {
-    console.error('IndexedDB Safari workaround failed', error);
-  }
-}
 
 function SessionRuntime() {
   const firebaseWithBridge = useContext(FirebaseBridgeContext);
@@ -76,8 +38,6 @@ function SessionRuntime() {
         PandaBridge.send('onSignedOut');
         return;
       }
-
-      fixIndexDbBug();
 
       unsubscribeUserDoc = firestore
         .collection('users')

--- a/src/hooks/useFirebaseWithBridge/changeActionController.mjs
+++ b/src/hooks/useFirebaseWithBridge/changeActionController.mjs
@@ -7,6 +7,26 @@ import {
   toQueuedChangeModify,
 } from './changeActionQueue.mjs';
 
+export const subscribeToChangeAuth = ({ auth, setUser, syncAuth }) => {
+  if (
+    auth === false ||
+    auth === null ||
+    typeof auth?.onIdTokenChanged !== 'function'
+  ) {
+    setUser(null);
+    syncAuth(auth);
+    return undefined;
+  }
+
+  const handleUser = (user) => {
+    setUser(user);
+    syncAuth({ currentUser: user });
+  };
+
+  handleUser(auth.currentUser ?? null);
+  return auth.onIdTokenChanged(handleUser);
+};
+
 export const createChangeActionController = ({
   applyChange,
   sendChangeError,
@@ -17,6 +37,7 @@ export const createChangeActionController = ({
 }) => {
   let pendingChanges = [];
   let timeoutId = null;
+  let synchronizedUid = null;
 
   const clearPendingTimeout = () => {
     if (timeoutId !== null) {
@@ -44,8 +65,10 @@ export const createChangeActionController = ({
     pendingChanges = [];
     clearPendingTimeout();
 
-    queued.forEach((modify) => {
-      applyChange({ user, modify });
+    queued.forEach(({ uid, modify }) => {
+      if (uid === null || uid === user.uid) {
+        applyChange({ user, modify });
+      }
     });
   };
 
@@ -64,10 +87,10 @@ export const createChangeActionController = ({
     }, timeoutMs);
   };
 
-  const enqueuePendingChange = (modify) => {
+  const enqueuePendingChange = (modify, uid = null) => {
     const { queue, dropped } = queueChangeModify({
       queue: pendingChanges,
-      modify,
+      modify: { uid, modify },
       maxSize: maxQueueSize,
     });
 
@@ -91,6 +114,10 @@ export const createChangeActionController = ({
     const authState = describeChangeAuthState(auth);
 
     if (authState === 'ready') {
+      if (auth.currentUser.uid !== synchronizedUid) {
+        enqueuePendingChange(modify, auth.currentUser.uid);
+        return;
+      }
       flushPendingChanges(auth.currentUser);
       applyChange({ user: auth.currentUser, modify });
       return;
@@ -117,6 +144,7 @@ export const createChangeActionController = ({
 
   const syncAuth = (auth) => {
     const authState = describeChangeAuthState(auth);
+    synchronizedUid = authState === 'ready' ? auth.currentUser.uid : null;
     const pendingPolicy = resolvePendingChangePolicy({
       authState,
       hasPendingChanges: pendingChanges.length > 0,

--- a/src/hooks/useFirebaseWithBridge/createChangeRuntime.mjs
+++ b/src/hooks/useFirebaseWithBridge/createChangeRuntime.mjs
@@ -1,0 +1,108 @@
+import { createFirestoreChangeWriter } from './firestoreChangeWriter.mjs';
+import { createUserDocSequencer } from './userDocSequencer.mjs';
+import { planChange } from './mutationPlanner.mjs';
+
+export const createChangeRuntime = ({
+  firestore,
+  FieldValue,
+  FieldPath,
+  JSONPointer,
+  ModifyData,
+  sendChangeError,
+  language,
+}) => {
+  const writer = createFirestoreChangeWriter({ FieldValue, FieldPath });
+
+  let authenticatedUid = null;
+  let currentDocRef = null;
+  let unsubscribe = null;
+
+  const sequencer = createUserDocSequencer({
+    planAction: ({ modify, userDoc }) =>
+      planChange({ JSONPointer, ModifyData, modify, userDoc, language }),
+    submitWrite: ({ plan }) => writer.submit({ docRef: currentDocRef, plan }),
+    readCache: () => {
+      if (!currentDocRef) {
+        return Promise.reject(new Error('No active user document.'));
+      }
+      return currentDocRef.get({ source: 'cache' }).then((snapshot) => ({
+        exists: snapshot.exists,
+        data: snapshot.data(),
+      }));
+    },
+    onChangeError: sendChangeError,
+  });
+
+  const clearListener = () => {
+    if (unsubscribe) {
+      const stopListening = unsubscribe;
+      unsubscribe = null;
+      stopListening();
+    }
+    currentDocRef = null;
+  };
+
+  const setUser = (user) => {
+    const nextUid = user ? user.uid : null;
+    const uidChanged = nextUid !== authenticatedUid;
+    if (!uidChanged && (nextUid === null || unsubscribe !== null)) {
+      return;
+    }
+
+    clearListener();
+    if (uidChanged) {
+      authenticatedUid = nextUid;
+      sequencer.setUid(nextUid);
+    }
+
+    if (!nextUid) {
+      return;
+    }
+
+    currentDocRef = firestore.collection('users').doc(nextUid);
+    unsubscribe = currentDocRef.onSnapshot(
+      { includeMetadataChanges: true },
+      (snapshot) => {
+        sequencer.handleSnapshot({
+          uid: nextUid,
+          exists: snapshot.exists,
+          fromCache: snapshot.metadata.fromCache,
+          getData: () => snapshot.data(),
+        });
+      },
+      (error) => {
+        if (authenticatedUid !== nextUid) {
+          return;
+        }
+        // eslint-disable-next-line no-console
+        console.error('Change runtime listener error:', error);
+        clearListener();
+        sequencer.handleListenerFailure({ uid: nextUid });
+        sendChangeError(
+          (error && error.code) || 'change/listener-failed',
+          (error && error.message) || String(error),
+        );
+      },
+    );
+  };
+
+  return {
+    setUser,
+    enqueue: ({ uid, modify }) => {
+      // A live UID with no docRef means the listener failed and is awaiting an
+      // ID-token refresh; drop the action loudly rather than stall it forever.
+      if (uid === authenticatedUid && !currentDocRef) {
+        sendChangeError(
+          'change/listener-unavailable',
+          'Change action dropped: the user document listener is unavailable.',
+        );
+        return;
+      }
+      sequencer.enqueue({ uid, modify });
+    },
+    dispose: () => {
+      clearListener();
+      sequencer.dispose();
+    },
+  };
+};

--- a/src/hooks/useFirebaseWithBridge/firebaseConfig.js
+++ b/src/hooks/useFirebaseWithBridge/firebaseConfig.js
@@ -48,7 +48,10 @@ const initializeFirebase = (config) => {
         console.log('Firestore persistence enabled');
       })
       .catch((error) => {
-        console.error('Error enabling Firestore persistence:', error);
+        console.warn(
+          'Firestore persistence unavailable; continuing with in-memory cache. Optimistic writes will not survive a reload.',
+          error,
+        );
       });
   } catch (error) {
     console.error('Error initializing Firebase:', error);

--- a/src/hooks/useFirebaseWithBridge/firestoreChangeWriter.mjs
+++ b/src/hooks/useFirebaseWithBridge/firestoreChangeWriter.mjs
@@ -1,0 +1,22 @@
+import { FIELD_PATH_UPDATES } from './modifyDataAdapter.mjs';
+import { toFirestoreValue } from './mutationSentinels.mjs';
+
+export const createFirestoreChangeWriter = ({ FieldValue, FieldPath }) => {
+  const submit = ({ docRef, plan }) => {
+    const args = [];
+    for (const [path, value] of Object.entries(plan.update)) {
+      args.push(path, toFirestoreValue(value, FieldValue));
+    }
+    for (const { segments, value } of plan.update[FIELD_PATH_UPDATES] || []) {
+      args.push(new FieldPath(...segments), toFirestoreValue(value, FieldValue));
+    }
+
+    if (args.length === 0) {
+      return Promise.resolve();
+    }
+
+    return docRef.update(...args);
+  };
+
+  return { submit };
+};

--- a/src/hooks/useFirebaseWithBridge/index.jsx
+++ b/src/hooks/useFirebaseWithBridge/index.jsx
@@ -7,7 +7,7 @@ import app from 'firebase/compat/app';
 import 'firebase/compat/auth';
 import 'firebase/compat/firestore';
 // import { setLogLevel } from 'firebase/app';
-import { useMemo, useEffect, useCallback } from 'react';
+import { useMemo, useEffect, useCallback, useRef } from 'react';
 
 import { JSONPointer, ModifyData } from '@beingenious/jsonpointer';
 import { initializeFirebase } from './firebaseConfig';
@@ -18,69 +18,26 @@ import {
 } from './emailLinkSignInActions.mjs';
 import { normalizeCollectionsForStorage } from './collectionStorageAdapter.mjs';
 import {
-  buildUserDocUpdate,
-  REPLACE_DOCUMENT_UPDATE,
-} from './modifyDataAdapter.mjs';
-import { createChangeActionController } from './changeActionController.mjs';
+  createChangeActionController,
+  subscribeToChangeAuth,
+} from './changeActionController.mjs';
+import { createChangeRuntime } from './createChangeRuntime.mjs';
 
 let firestore = null;
 let auth = null;
 
 // setLogLevel('debug');
 
-const changeData = ({ user, modify }) => {
-  const userDocRef = firestore.collection('users').doc(user.uid);
-
-  firestore
-    .runTransaction((transaction) =>
-      transaction.get(userDocRef).then((userDoc) => {
-        if (userDoc.exists) {
-          const userData = userDoc.data();
-
-          const update = buildUserDocUpdate({
-            JSONPointer,
-            ModifyData,
-            userData,
-            modify,
-            FieldValue: app.firestore.FieldValue,
-            language: navigator.language.replace('-', '_'),
-          });
-          if (update) {
-            if (
-              Object.prototype.hasOwnProperty.call(
-                update,
-                REPLACE_DOCUMENT_UPDATE,
-              )
-            ) {
-              transaction.set(userDocRef, update[REPLACE_DOCUMENT_UPDATE]);
-            } else {
-              transaction.update(userDocRef, update);
-            }
-          }
-        }
-      }),
-    )
-    .catch((error) => {
-      // eslint-disable-next-line no-console
-      console.log(error);
-      PandaBridge.send('onChangeError', [
-        {
-          code: (error && error.code) || 'unknown',
-          message: (error && error.message) || String(error),
-        },
-      ]);
-    });
-};
-
 function useFirebaseWithBridge() {
   const sendChangeError = useCallback((code, message) => {
     PandaBridge.send('onChangeError', [{ code, message }]);
   }, []);
+  const changeRuntimeRef = useRef(null);
   const changeActionController = useMemo(
     () =>
       createChangeActionController({
         applyChange: ({ user, modify }) => {
-          changeData({ user, modify });
+          changeRuntimeRef.current?.enqueue({ uid: user.uid, modify });
         },
         sendChangeError,
       }),
@@ -216,24 +173,42 @@ function useFirebaseWithBridge() {
     }
   }, [mergedProperties]);
 
-  useEffect(() => {
-    if (
-      auth === false ||
-      auth === null ||
-      typeof auth?.onAuthStateChanged !== 'function'
-    ) {
-      changeActionController.syncAuth(auth);
-      return undefined;
+  const changeRuntime = useMemo(() => {
+    if (!firestore) {
+      return null;
     }
-
-    changeActionController.syncAuth(auth);
-
-    const unsubscribe = auth.onAuthStateChanged((user) => {
-      changeActionController.syncAuth({ currentUser: user });
+    return createChangeRuntime({
+      firestore,
+      FieldValue: app.firestore.FieldValue,
+      FieldPath: app.firestore.FieldPath,
+      JSONPointer,
+      ModifyData,
+      sendChangeError,
+      language: navigator.language.replace('-', '_'),
     });
+  }, [firestore, sendChangeError]);
 
-    return () => unsubscribe();
-  }, [auth, changeActionController]);
+  useEffect(() => {
+    changeRuntimeRef.current = changeRuntime;
+    return () => {
+      if (changeRuntime) {
+        changeRuntime.dispose();
+      }
+      if (changeRuntimeRef.current === changeRuntime) {
+        changeRuntimeRef.current = null;
+      }
+    };
+  }, [changeRuntime]);
+
+  useEffect(
+    () =>
+      subscribeToChangeAuth({
+        auth,
+        setUser: (user) => changeRuntimeRef.current?.setUser(user),
+        syncAuth: changeActionController.syncAuth,
+      }),
+    [auth, changeActionController, changeRuntime],
+  );
 
   useEffect(
     () => () => {

--- a/src/hooks/useFirebaseWithBridge/modifyDataAdapter.mjs
+++ b/src/hooks/useFirebaseWithBridge/modifyDataAdapter.mjs
@@ -12,7 +12,34 @@ import {
 } from './collectionStorageAdapter.mjs';
 import { buildPointerPlan } from './pointerPlanner.mjs';
 
-export const REPLACE_DOCUMENT_UPDATE = Symbol('replaceDocumentUpdate');
+export const FIELD_PATH_UPDATES = Symbol('fieldPathUpdates');
+
+const FIRESTORE_FIELD_PATH_METACHARACTERS = ['.', '~', '*', '/', '[', ']'];
+
+const requiresStructuredFieldPath = (segment) =>
+  FIRESTORE_FIELD_PATH_METACHARACTERS.some((character) =>
+    segment.includes(character),
+  );
+
+const buildFieldPathAwareUpdate = (entries) => {
+  const update = {};
+  const fieldPathUpdates = [];
+
+  for (const { segments, value } of entries) {
+    const stringSegments = segments.map(String);
+    if (stringSegments.some(requiresStructuredFieldPath)) {
+      fieldPathUpdates.push({ segments: stringSegments, value });
+    } else {
+      update[stringSegments.join('.')] = value;
+    }
+  }
+
+  if (fieldPathUpdates.length > 0) {
+    update[FIELD_PATH_UPDATES] = fieldPathUpdates;
+  }
+
+  return update;
+};
 
 const rawPandaValue = (value) => {
   if (value && typeof value === 'object' && typeof value.type === 'string') {
@@ -21,11 +48,25 @@ const rawPandaValue = (value) => {
   return value;
 };
 
+const rawModifyDataValue = (value) => {
+  if (value && typeof value === 'object' && value.value !== undefined) {
+    return value.type === 'Page'
+      ? _.get(value, 'value.did', null)
+      : value.value;
+  }
+  return value;
+};
+
+const toFiniteOperand = (value) => (Number.isFinite(value) ? value : 0);
+
 const isPandaValueWrapper = (value) =>
   !!value &&
   typeof value === 'object' &&
   typeof value.type === 'string' &&
   Object.prototype.hasOwnProperty.call(value, 'value');
+
+const hasWrappedValue = (value) =>
+  !!value && typeof value === 'object' && !!value.value;
 
 const unwrapCollectionsForPlanner = (value) => {
   if (Array.isArray(value)) {
@@ -41,6 +82,10 @@ const unwrapCollectionsForPlanner = (value) => {
       return value.value.map(unwrapCollectionsForPlanner);
     }
     return toLogicalCollectionValue(value);
+  }
+
+  if (!_.isPlainObject(value)) {
+    return value;
   }
 
   const output = {};
@@ -116,9 +161,9 @@ const getOutputValueAtPath = ({
 
 const buildTargetedCollectionSetUpdate = ({
   collection,
-  basePath,
+  baseSegments,
   id,
-  tailPath,
+  tailSegments,
   value,
 }) => {
   const normalized = normalizeCollection(collection);
@@ -129,71 +174,279 @@ const buildTargetedCollectionSetUpdate = ({
   }
 
   if (isCanonicalCollectionWrapper(collection)) {
-    const path = tailPath
-      ? `${basePath}.valueById.${encodedId}.${tailPath}`
-      : `${basePath}.valueById.${encodedId}`;
-
-    return { [path]: value };
+    return buildFieldPathAwareUpdate([
+      {
+        segments: [
+          ...baseSegments,
+          'valueById',
+          encodedId,
+          ...tailSegments,
+        ],
+        value,
+      },
+    ]);
   }
 
   const nextCollection = toCanonicalCollectionForStorage(collection);
   const nextRow = _.cloneDeep(nextCollection.valueById[encodedId]);
 
-  if (tailPath) {
+  if (tailSegments.length > 0) {
     const patchableRow =
       nextRow && typeof nextRow === 'object' ? nextRow : Object.create(null);
-    _.set(patchableRow, tailPath, value);
+    _.set(patchableRow, tailSegments, value);
     nextCollection.valueById[encodedId] = patchableRow;
   } else {
     nextCollection.valueById[encodedId] = value;
   }
 
-  return {
-    [basePath]: nextCollection,
-  };
+  return buildFieldPathAwareUpdate([
+    { segments: baseSegments, value: nextCollection },
+  ]);
 };
 
+// Firestore's arrayUnion/arrayRemove match by exact value, so membership
+// transforms must target the value actually stored in `order` (which may be
+// an unnormalized numeric id). Returns undefined unless exactly one stored
+// entry matches the normalized id — callers then fall back to a rewrite.
+const getExactMembershipValue = (collection, id) => {
+  const rawOrder = Array.isArray(collection?.order) ? collection.order : [];
+  const matches = rawOrder.filter((rawId) => String(rawId) === id);
+  return matches.length === 1 ? matches[0] : undefined;
+};
+
+const getStoredCollectionRowKey = (collection, id) => {
+  const stringId = String(id);
+  const encodedId = encodeIdKey(stringId);
+  const valueById = collection?.valueById;
+
+  if (valueById && typeof valueById === 'object') {
+    if (hasOwn(valueById, encodedId)) {
+      return encodedId;
+    }
+    if (hasOwn(valueById, stringId)) {
+      return stringId;
+    }
+  }
+
+  return encodedId;
+};
+
+// Emits the two-entry update that atomically drops a row: `arrayRemove` on the
+// membership `order` plus `delete()` on the `valueById` entry.
+const buildMembershipDeleteUpdate = ({
+  baseSegments,
+  membershipValues,
+  rowKey,
+  FieldValue,
+}) =>
+  buildFieldPathAwareUpdate([
+    {
+      segments: [...baseSegments, 'order'],
+      value: FieldValue.arrayRemove(...membershipValues),
+    },
+    {
+      segments: [...baseSegments, 'valueById', rowKey],
+      value: FieldValue.delete(),
+    },
+  ]);
+
 const buildCanonicalCollectionAddFastUpdate = ({
-  basePath,
+  baseSegments,
   originalCollection,
   logicalCollection,
+  addedValue,
+  FieldValue,
 }) => {
-  if (!isCanonicalCollectionWrapper(originalCollection)) {
+  if (!isCanonicalCollectionWrapper(originalCollection) || !FieldValue) {
     return null;
   }
 
   const before = normalizeCollection(originalCollection);
   const after = normalizeCollection(logicalCollection);
 
-  if (after.order.length !== before.order.length + 1) {
+  const isAppend =
+    after.order.length === before.order.length + 1 &&
+    _.isEqual(after.order.slice(0, before.order.length), before.order);
+  const isSameOrder = _.isEqual(after.order, before.order);
+
+  if (!isAppend && !isSameOrder) {
     return null;
   }
 
-  const sharedPrefix = after.order.slice(0, before.order.length);
-  if (!_.isEqual(sharedPrefix, before.order)) {
+  const changedIds = [];
+  for (const id of after.order) {
+    const key = encodeIdKey(id);
+    if (!_.isEqual(after.valueById[key], before.valueById[key])) {
+      changedIds.push(id);
+    }
+  }
+
+  if (changedIds.length === 0 && isSameOrder) {
+    const addedId = rawPandaValue(addedValue?.id);
+    const normalizedId = addedId == null ? null : String(addedId);
+    if (
+      normalizedId !== null &&
+      hasOwn(after.valueById, encodeIdKey(normalizedId))
+    ) {
+      changedIds.push(normalizedId);
+    }
+  }
+
+  if (changedIds.length !== 1) {
     return null;
   }
 
-  const appendedId = after.order[after.order.length - 1];
-  const encodedId = encodeIdKey(appendedId);
-
-  if (
-    hasOwn(before.valueById, encodedId) ||
-    !hasOwn(after.valueById, encodedId)
-  ) {
+  const [changedId] = changedIds;
+  if (isAppend && after.order[after.order.length - 1] !== changedId) {
     return null;
   }
 
-  for (const [key, row] of Object.entries(before.valueById)) {
-    if (!_.isEqual(after.valueById[key], row)) {
+  let membershipValue = changedId;
+  if (isSameOrder) {
+    membershipValue = getExactMembershipValue(originalCollection, changedId);
+    if (membershipValue === undefined) {
       return null;
     }
   }
 
-  return {
-    [`${basePath}.order`]: after.order,
-    [`${basePath}.valueById.${encodedId}`]: after.valueById[encodedId],
-  };
+  const encodedId = encodeIdKey(changedId);
+  return buildFieldPathAwareUpdate([
+    {
+      segments: [...baseSegments, 'order'],
+      value: FieldValue.arrayUnion(membershipValue),
+    },
+    {
+      segments: [...baseSegments, 'valueById', encodedId],
+      value: after.valueById[encodedId],
+    },
+  ]);
+};
+
+const buildCanonicalCollectionDeleteByIdUpdate = ({
+  baseSegments,
+  originalCollection,
+  id,
+  FieldValue,
+}) => {
+  if (!isCanonicalCollectionWrapper(originalCollection) || !FieldValue) {
+    return null;
+  }
+
+  const rawId = rawModifyDataValue(id);
+  if (rawId === null || rawId === undefined) {
+    return null;
+  }
+
+  const stringId = String(rawId);
+  const membershipMatches = originalCollection.order.filter(
+    (storedId) => String(storedId) === stringId,
+  );
+  if (membershipMatches.length > 1) {
+    return null;
+  }
+
+  let membershipValues;
+  if (membershipMatches.length === 1) {
+    membershipValues = membershipMatches;
+  } else {
+    // Row absent locally: the remote membership may be stored as either the
+    // string id or its numeric form, so arrayRemove must target both.
+    membershipValues = [stringId];
+    const numericId = Number(stringId);
+    if (String(numericId) === stringId) {
+      membershipValues.push(numericId);
+    }
+  }
+  return buildMembershipDeleteUpdate({
+    baseSegments,
+    membershipValues,
+    rowKey: getStoredCollectionRowKey(originalCollection, stringId),
+    FieldValue,
+  });
+};
+
+const buildCanonicalCollectionDeleteFastUpdate = ({
+  baseSegments,
+  originalCollection,
+  logicalCollection,
+  FieldValue,
+}) => {
+  if (!isCanonicalCollectionWrapper(originalCollection) || !FieldValue) {
+    return null;
+  }
+
+  const before = normalizeCollection(originalCollection);
+  const after = normalizeCollection(logicalCollection);
+
+  if (after.order.length !== before.order.length - 1) {
+    return null;
+  }
+
+  const afterIds = new Set(after.order);
+  const removedIds = before.order.filter((id) => !afterIds.has(id));
+  if (removedIds.length !== 1) {
+    return null;
+  }
+
+  const [removedId] = removedIds;
+  if (
+    !_.isEqual(
+      after.order,
+      before.order.filter((id) => id !== removedId),
+    )
+  ) {
+    return null;
+  }
+
+  for (const id of after.order) {
+    const key = encodeIdKey(id);
+    if (!_.isEqual(after.valueById[key], before.valueById[key])) {
+      return null;
+    }
+  }
+
+  const membershipValue = getExactMembershipValue(originalCollection, removedId);
+  if (membershipValue === undefined) {
+    return null;
+  }
+
+  return buildMembershipDeleteUpdate({
+    baseSegments,
+    membershipValues: [membershipValue],
+    rowKey: getStoredCollectionRowKey(originalCollection, removedId),
+    FieldValue,
+  });
+};
+
+// Deleting a whole row must fix membership too: dropping only the valueById
+// entry would leave a dangling id in `order`.
+const buildCanonicalRowDeleteUpdate = ({
+  collection,
+  baseSegments,
+  id,
+  FieldValue,
+}) => {
+  if (!FieldValue) {
+    return null;
+  }
+
+  const stringId = String(id);
+  const membershipValue = getExactMembershipValue(collection, stringId);
+  if (membershipValue === undefined) {
+    return null;
+  }
+
+  const encodedId = encodeIdKey(stringId);
+  if (!hasOwn(normalizeCollection(collection).valueById, encodedId)) {
+    return null;
+  }
+
+  return buildMembershipDeleteUpdate({
+    baseSegments,
+    membershipValues: [membershipValue],
+    rowKey: getStoredCollectionRowKey(collection, stringId),
+    FieldValue,
+  });
 };
 
 const isPointerObjectArray = (value) =>
@@ -216,6 +469,14 @@ const getPointerObjects = ({ JSONPointer, property }) => {
   }
 
   return JSONPointer.getPointerByJSONPointer(property);
+};
+
+export const parsePointerObjects = ({ JSONPointer, property }) => {
+  try {
+    return getPointerObjects({ JSONPointer, property }) || [];
+  } catch {
+    return [];
+  }
 };
 
 const toPathSegments = (pointerObjects) =>
@@ -261,7 +522,7 @@ const applyModifyInPlaceSafely = ({
       obj: { unitPool: { language: language || 'en_US' } },
     });
   } catch {
-    return false;
+    return null;
   }
 };
 
@@ -324,56 +585,40 @@ const getDocumentFromPointer = (userData, pointer, value) => {
   const index = _.findIndex(pointer, (key) => _.isNumber(key));
   const firstUnaddressableSegmentIndex = _.findIndex(
     pointer,
-    (segment) => typeof segment === 'string' && segment.includes('.'),
+    (segment) =>
+      typeof segment === 'string' && requiresStructuredFieldPath(segment),
   );
-  if (
-    firstUnaddressableSegmentIndex >= 0 &&
-    (index === -1 || index > firstUnaddressableSegmentIndex)
-  ) {
-    if (firstUnaddressableSegmentIndex === 0) {
-      const nextDocument =
-        userData && typeof userData === 'object'
-          ? _.cloneDeep(userData)
-          : Object.create(null);
-      _.set(nextDocument, pointer, value);
-      return { [REPLACE_DOCUMENT_UPDATE]: nextDocument };
-    }
-
-    const parentPath = pointer
-      .slice(0, firstUnaddressableSegmentIndex)
-      .join('.');
-    const tailPath = pointer.slice(firstUnaddressableSegmentIndex);
-    const subtree = _.get(userData, parentPath);
-    const patchableSubtree =
-      subtree && typeof subtree === 'object'
-        ? _.cloneDeep(subtree)
-        : typeof tailPath[0] === 'number'
-          ? []
-          : Object.create(null);
-
-    _.set(patchableSubtree, tailPath, value);
-    update[parentPath] = patchableSubtree;
-    return update;
-  }
 
   if (index !== -1) {
-    const path = pointer.slice(0, index).join('.');
-    const subtree = _.get(userData, path);
-    update[path] = _.cloneDeep(subtree);
-    _.set(update[path], pointer.slice(index), value);
-  } else {
-    update[pointer.join('.')] = value;
+    const parentSegments = pointer.slice(0, index);
+    const subtree = _.cloneDeep(_.get(userData, parentSegments));
+    _.set(subtree, pointer.slice(index), value);
+    return buildFieldPathAwareUpdate([
+      { segments: parentSegments, value: subtree },
+    ]);
   }
+
+  if (firstUnaddressableSegmentIndex >= 0) {
+    return {
+      [FIELD_PATH_UPDATES]: [{ segments: pointer.map(String), value }],
+    };
+  }
+
+  update[pointer.join('.')] = value;
   return update;
 };
 
-export const buildUserDocUpdate = ({
+const classifyUpdate = (category, update) =>
+  update ? { category, update } : null;
+
+export const buildClassifiedUserDocUpdate = ({
   JSONPointer,
   ModifyData,
   userData,
   modify,
   FieldValue,
   language,
+  pointerObjects: providedPointerObjects,
 }) => {
   if (!userData || typeof userData !== 'object') {
     return null;
@@ -386,10 +631,16 @@ export const buildUserDocUpdate = ({
   const logicalUserData = hydrateCollectionsForLogicalUse(userData);
   const plannerUserData = unwrapCollectionsForPlanner(logicalUserData);
   const func = (modify.func || 'set').toLowerCase();
-  const pointerObjects = getPointerObjects({
-    JSONPointer,
-    property: modify.property,
-  });
+  const isAtomicTransform =
+    func === 'inc' ||
+    func === 'dec' ||
+    func === 'del' ||
+    func === 'add' ||
+    func === 'delbyid' ||
+    func === 'delbyvalue';
+  const pointerObjects =
+    providedPointerObjects ||
+    getPointerObjects({ JSONPointer, property: modify.property });
   if (pointerObjects.length === 0) {
     return null;
   }
@@ -405,7 +656,13 @@ export const buildUserDocUpdate = ({
       JSONPointer.isFunctionTypeComputedSelector(ptr.func),
   );
 
-  if (func === 'set') {
+  // `add` is excluded from the canonical fast path: arrayUnion cannot
+  // express ModifyData's ID-upsert semantics (adding {id, ...} over an
+  // existing same-ID row must merge, not append a duplicate).
+  const canTargetCanonicalRow = isAtomicTransform && func !== 'add';
+
+  let targeted = null;
+  if (func === 'set' || canTargetCanonicalRow) {
     const plan = buildPointerPlan({
       JSONPointer,
       userData: plannerUserData,
@@ -414,20 +671,122 @@ export const buildUserDocUpdate = ({
     });
 
     if (plan.kind === 'targeted') {
-      const baseValue = _.get(userData, plan.basePath);
-      if (isCollectionWrapper(baseValue)) {
-        return buildTargetedCollectionSetUpdate({
-          collection: baseValue,
-          basePath: plan.basePath,
-          id: plan.id,
-          tailPath: plan.tailPath,
-          value: modify.value,
-        });
+      const selectorIndex = Math.min(
+        ...[firstArraySelectorIndex, firstComputedSelectorIndex].filter(
+          (index) => index >= 0,
+        ),
+      );
+      const baseSegments = getStableParentSegments(
+        pointerObjects,
+        selectorIndex,
+      );
+      targeted = {
+        id: plan.id,
+        baseSegments,
+        tailSegments: pointerObjects
+          .slice(selectorIndex + 1)
+          .map((ptr) => ptr.value),
+        baseValue: _.get(userData, baseSegments),
+      };
+    }
+  }
+
+  if (func === 'set' && targeted && isCollectionWrapper(targeted.baseValue)) {
+    const update = buildTargetedCollectionSetUpdate({
+      collection: targeted.baseValue,
+      baseSegments: targeted.baseSegments,
+      id: targeted.id,
+      tailSegments: targeted.tailSegments,
+      value: modify.value,
+    });
+    return classifyUpdate(
+      isCanonicalCollectionWrapper(targeted.baseValue)
+        ? 'targeted-write'
+        : 'local-rewrite',
+      update,
+    );
+  }
+
+  let canonicalTransformPointer = null;
+  if (
+    canTargetCanonicalRow &&
+    targeted &&
+    isCanonicalCollectionWrapper(targeted.baseValue)
+  ) {
+    if (func === 'del' && targeted.tailSegments.length === 0) {
+      const update = buildCanonicalRowDeleteUpdate({
+        collection: targeted.baseValue,
+        baseSegments: targeted.baseSegments,
+        id: targeted.id,
+        FieldValue,
+      });
+      if (update) {
+        return classifyUpdate('atomic-transform', update);
+      }
+      // Ambiguous membership: fall through to a ModifyData local rewrite.
+    } else {
+      const rowPointer = [
+        ...targeted.baseSegments,
+        'valueById',
+        encodeIdKey(targeted.id),
+        ...targeted.tailSegments,
+      ];
+      const currentValue = _.get(userData, rowPointer);
+      if (func === 'inc' || func === 'dec') {
+        const firestoreOperand = toFiniteOperand(
+          Number(rawPandaValue(modify.value)),
+        );
+        const modifyDataOperand = toFiniteOperand(
+          parseFloat(rawModifyDataValue(modify.value)),
+        );
+
+        let isMissingMapLeaf = false;
+        if (currentValue === undefined) {
+          const currentParent = _.get(userData, rowPointer.slice(0, -1));
+          isMissingMapLeaf =
+            _.isPlainObject(currentParent) && !isPandaValueWrapper(currentParent);
+        }
+
+        if (
+          (Number.isFinite(currentValue) || isMissingMapLeaf) &&
+          firestoreOperand === modifyDataOperand
+        ) {
+          canonicalTransformPointer = rowPointer;
+        }
+      } else if (func === 'del') {
+        if (!isPandaValueWrapper(currentValue)) {
+          canonicalTransformPointer = rowPointer;
+        }
+      } else if (func === 'delbyid') {
+        // ModifyData intentionally treats numeric and string IDs as equivalent.
+        const idToRemove = rawModifyDataValue(modify.value);
+        const matchingRows =
+          idToRemove != null && Array.isArray(currentValue)
+            ? currentValue.filter(
+                // eslint-disable-next-line eqeqeq
+                (row) => rawModifyDataValue(row?.id) == idToRemove,
+              )
+            : [];
+
+        if (
+          matchingRows.length === 1 &&
+          rawPandaValue(matchingRows[0]?.id) === rawPandaValue(modify.value)
+        ) {
+          canonicalTransformPointer = rowPointer;
+        }
+      } else if (func === 'delbyvalue') {
+        if (
+          Array.isArray(currentValue) &&
+          !hasWrappedValue(modify.value) &&
+          !currentValue.some(hasWrappedValue)
+        ) {
+          canonicalTransformPointer = rowPointer;
+        }
       }
     }
   }
 
-  if (firstComputedSelectorIndex !== -1) {
+  if (firstComputedSelectorIndex !== -1 && canonicalTransformPointer === null) {
     if (!ModifyData) {
       return null;
     }
@@ -439,7 +798,6 @@ export const buildUserDocUpdate = ({
     if (!baseSegments || baseSegments.length === 0) {
       return null;
     }
-
     const changed = applyModifyInPlaceSafely({
       ModifyData,
       userData: logicalUserData,
@@ -447,8 +805,23 @@ export const buildUserDocUpdate = ({
       language,
     });
 
-    if (!changed) {
+    if (changed === null) {
       return null;
+    }
+
+    if (!changed) {
+      const selectorResolved =
+        func === 'set' &&
+        resolvePointerSegments({
+          JSONPointer,
+          schema: logicalUserData,
+          property: modify.property,
+          language,
+          allowFallback: false,
+        }).length > 0;
+      if (!selectorResolved) {
+        return null;
+      }
     }
 
     const outputValue = getOutputValueAtPath({
@@ -456,10 +829,17 @@ export const buildUserDocUpdate = ({
       logicalUserData,
       baseSegments,
     });
-    return getDocumentFromPointer(userData, baseSegments, outputValue);
+    return classifyUpdate(
+      'local-rewrite',
+      getDocumentFromPointer(userData, baseSegments, outputValue),
+    );
   }
 
-  if (firstArraySelectorIndex !== -1 && func !== 'set') {
+  if (
+    firstArraySelectorIndex !== -1 &&
+    func !== 'set' &&
+    canonicalTransformPointer === null
+  ) {
     if (!ModifyData) {
       return null;
     }
@@ -488,19 +868,24 @@ export const buildUserDocUpdate = ({
       logicalUserData,
       baseSegments,
     });
-    return getDocumentFromPointer(userData, baseSegments, outputValue);
+    return classifyUpdate(
+      'local-rewrite',
+      getDocumentFromPointer(userData, baseSegments, outputValue),
+    );
   }
 
   const hasGetById = pointerObjects.some((ptr) => ptr?.func === 'getById');
-  const pointer = hasGetById
-    ? resolvePointerSegments({
-        JSONPointer,
-        schema: logicalUserData,
-        property: modify.property,
-        language,
-        allowFallback: false,
-      })
-    : toPathSegments(pointerObjects);
+  const pointer =
+    canonicalTransformPointer ||
+    (hasGetById
+      ? resolvePointerSegments({
+          JSONPointer,
+          schema: logicalUserData,
+          property: modify.property,
+          language,
+          allowFallback: false,
+        })
+      : toPathSegments(pointerObjects));
 
   if (pointer.length === 0) {
     return null;
@@ -510,8 +895,24 @@ export const buildUserDocUpdate = ({
     return null;
   }
 
-  const pointerPath = pointer.join('.');
-  const targetAtPointer = _.get(logicalUserData, pointerPath);
+  const targetAtPointer = _.get(logicalUserData, pointer);
+  const originalAtPointer = _.get(userData, pointer);
+
+  if (
+    func === 'delbyid' &&
+    isCanonicalCollectionWrapper(originalAtPointer)
+  ) {
+    const update = buildCanonicalCollectionDeleteByIdUpdate({
+      baseSegments: pointer,
+      originalCollection: originalAtPointer,
+      id: modify.value,
+      FieldValue,
+    });
+    if (update) {
+      return classifyUpdate('atomic-transform', update);
+    }
+  }
+
   const requiresWrapperSafeMutation =
     (func === 'add' || func === 'delbyid' || func === 'delbyvalue') &&
     isPandaValueWrapper(targetAtPointer);
@@ -532,8 +933,7 @@ export const buildUserDocUpdate = ({
       return null;
     }
 
-    const originalAtPointer = _.get(userData, pointerPath);
-    const logicalAtPointer = _.get(logicalUserData, pointerPath);
+    const logicalAtPointer = _.get(logicalUserData, pointer);
     const outputValue =
       isCollectionWrapper(originalAtPointer) &&
       isCollectionWrapper(logicalAtPointer)
@@ -549,16 +949,37 @@ export const buildUserDocUpdate = ({
       isCollectionWrapper(logicalAtPointer)
     ) {
       const fastUpdate = buildCanonicalCollectionAddFastUpdate({
-        basePath: pointerPath,
+        baseSegments: pointer,
         originalCollection: originalAtPointer,
         logicalCollection: logicalAtPointer,
+        addedValue: modify.value,
+        FieldValue,
       });
       if (fastUpdate) {
-        return fastUpdate;
+        return classifyUpdate('atomic-transform', fastUpdate);
       }
     }
 
-    return getDocumentFromPointer(logicalUserData, pointer, outputValue);
+    if (
+      (func === 'delbyid' || func === 'delbyvalue') &&
+      isCollectionWrapper(originalAtPointer) &&
+      isCollectionWrapper(logicalAtPointer)
+    ) {
+      const fastUpdate = buildCanonicalCollectionDeleteFastUpdate({
+        baseSegments: pointer,
+        originalCollection: originalAtPointer,
+        logicalCollection: logicalAtPointer,
+        FieldValue,
+      });
+      if (fastUpdate) {
+        return classifyUpdate('atomic-transform', fastUpdate);
+      }
+    }
+
+    return classifyUpdate(
+      'local-rewrite',
+      getDocumentFromPointer(logicalUserData, pointer, outputValue),
+    );
   }
 
   if (!FieldValue) {
@@ -583,7 +1004,7 @@ export const buildUserDocUpdate = ({
   } else if (func === 'add') {
     fieldValue = FieldValue.arrayUnion(modify.value);
   } else if (func === 'delbyid') {
-    let base = _.get(userData, pointer.join('.'));
+    let base = _.get(userData, pointer);
     if (base && base.value && Array.isArray(base.value)) {
       base = base.value;
     }
@@ -598,5 +1019,20 @@ export const buildUserDocUpdate = ({
     fieldValue = FieldValue.arrayRemove(modify.value);
   }
 
-  return getDocumentFromPointer(userData, pointer, fieldValue);
+  let category = 'targeted-write';
+  if (isAtomicTransform) {
+    category = 'atomic-transform';
+  } else if (func === 'set' && firstArraySelectorIndex !== -1) {
+    category = 'local-rewrite';
+  }
+
+  return classifyUpdate(
+    category,
+    getDocumentFromPointer(userData, pointer, fieldValue),
+  );
+};
+
+export const buildUserDocUpdate = (args) => {
+  const classified = buildClassifiedUserDocUpdate(args);
+  return classified ? classified.update : null;
 };

--- a/src/hooks/useFirebaseWithBridge/mutationPlanner.mjs
+++ b/src/hooks/useFirebaseWithBridge/mutationPlanner.mjs
@@ -1,0 +1,55 @@
+import {
+  buildClassifiedUserDocUpdate,
+  parsePointerObjects,
+} from './modifyDataAdapter.mjs';
+import { applyUpdateToDoc, plannerFieldValue } from './mutationSentinels.mjs';
+
+export const planChange = ({
+  JSONPointer,
+  ModifyData,
+  modify,
+  userDoc,
+  language,
+}) => {
+  if (
+    !modify ||
+    typeof modify !== 'object' ||
+    modify.property == null ||
+    (modify.func != null && typeof modify.func !== 'string')
+  ) {
+    return { kind: 'invalid', reason: 'change/malformed-action' };
+  }
+
+  const pointerObjects = parsePointerObjects({
+    JSONPointer,
+    property: modify.property,
+  });
+  if (pointerObjects.length === 0) {
+    return { kind: 'invalid', reason: 'change/invalid-pointer' };
+  }
+
+  const baseDoc = userDoc && typeof userDoc === 'object' ? userDoc : {};
+
+  // buildClassifiedUserDocUpdate never mutates userData (guarded by the
+  // "planner purity" test), so the long-lived planning doc is passed as is.
+  const classified = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: baseDoc,
+    modify,
+    FieldValue: plannerFieldValue,
+    language,
+    pointerObjects,
+  });
+
+  if (!classified) {
+    return { kind: 'noop' };
+  }
+
+  const expectedDoc = applyUpdateToDoc({
+    doc: baseDoc,
+    update: classified.update,
+  });
+
+  return { kind: classified.category, update: classified.update, expectedDoc };
+};

--- a/src/hooks/useFirebaseWithBridge/mutationSentinels.mjs
+++ b/src/hooks/useFirebaseWithBridge/mutationSentinels.mjs
@@ -1,0 +1,135 @@
+import _ from 'lodash';
+
+import { FIELD_PATH_UPDATES } from './modifyDataAdapter.mjs';
+
+const SENTINEL_KEY = '__pandaFsSentinel';
+const SENTINEL_BRAND = Symbol('pandaFsSentinel');
+
+export const plannerFieldValue = {
+  increment: (operand) => ({
+    [SENTINEL_BRAND]: true,
+    [SENTINEL_KEY]: 'increment',
+    operand,
+  }),
+  delete: () => ({
+    [SENTINEL_BRAND]: true,
+    [SENTINEL_KEY]: 'delete',
+  }),
+  arrayUnion: (...values) => ({
+    [SENTINEL_BRAND]: true,
+    [SENTINEL_KEY]: 'arrayUnion',
+    values,
+  }),
+  arrayRemove: (...values) => ({
+    [SENTINEL_BRAND]: true,
+    [SENTINEL_KEY]: 'arrayRemove',
+    values,
+  }),
+};
+
+export const isSentinel = (value) =>
+  !!value &&
+  typeof value === 'object' &&
+  value[SENTINEL_BRAND] === true &&
+  typeof value[SENTINEL_KEY] === 'string';
+
+const applySentinel = (current, sentinel) => {
+  const kind = sentinel[SENTINEL_KEY];
+
+  if (kind === 'increment') {
+    // Firestore applies IEEE arithmetic to any numeric current value
+    // (NaN stays NaN, infinities stay infinite) and only substitutes the
+    // operand when the field is missing or non-numeric.
+    return typeof current === 'number'
+      ? current + sentinel.operand
+      : sentinel.operand;
+  }
+
+  if (kind === 'arrayUnion') {
+    const base = Array.isArray(current) ? [...current] : [];
+    for (const value of sentinel.values) {
+      if (!base.some((item) => _.isEqual(item, value))) {
+        base.push(_.cloneDeep(value));
+      }
+    }
+    return base;
+  }
+
+  if (kind === 'arrayRemove') {
+    const base = Array.isArray(current) ? current : [];
+    return base.filter(
+      (item) => !sentinel.values.some((value) => _.isEqual(item, value)),
+    );
+  }
+
+  return undefined;
+};
+
+const setAtSegments = (target, segments, value) => {
+  if (segments.some((segment) => String(segment) === '__proto__')) {
+    return;
+  }
+
+  const isDelete = isSentinel(value) && value[SENTINEL_KEY] === 'delete';
+
+  let cursor = target;
+  for (let i = 0; i < segments.length - 1; i += 1) {
+    const key = String(segments[i]);
+    if (!_.isPlainObject(cursor[key])) {
+      if (isDelete) {
+        // Firestore leaves the document untouched when a nested delete
+        // targets a missing or non-map parent; never materialize parents.
+        return;
+      }
+      cursor[key] = {};
+    }
+    cursor = cursor[key];
+  }
+
+  const leaf = String(segments[segments.length - 1]);
+  const current = cursor[leaf];
+
+  if (isSentinel(value)) {
+    if (value[SENTINEL_KEY] === 'delete') {
+      delete cursor[leaf];
+      return;
+    }
+    cursor[leaf] = applySentinel(current, value);
+    return;
+  }
+
+  cursor[leaf] = _.cloneDeep(value);
+};
+
+export const applyUpdateToDoc = ({ doc, update }) => {
+  const next = doc && typeof doc === 'object' ? _.cloneDeep(doc) : {};
+
+  for (const [path, value] of Object.entries(update || {})) {
+    setAtSegments(next, path.split('.'), value);
+  }
+
+  const fieldPathEntries = (update && update[FIELD_PATH_UPDATES]) || [];
+  for (const { segments, value } of fieldPathEntries) {
+    setAtSegments(next, segments, value);
+  }
+
+  return next;
+};
+
+export const toFirestoreValue = (value, FieldValue) => {
+  if (!isSentinel(value)) {
+    return value;
+  }
+
+  const kind = value[SENTINEL_KEY];
+  if (kind === 'increment') {
+    return FieldValue.increment(value.operand);
+  }
+  if (kind === 'delete') {
+    return FieldValue.delete();
+  }
+  if (kind === 'arrayUnion') {
+    return FieldValue.arrayUnion(...value.values);
+  }
+  return FieldValue.arrayRemove(...value.values);
+};

--- a/src/hooks/useFirebaseWithBridge/userDocSequencer.mjs
+++ b/src/hooks/useFirebaseWithBridge/userDocSequencer.mjs
@@ -1,0 +1,269 @@
+const EXISTENCE = {
+  UNKNOWN: 'unknown',
+  EXISTS: 'exists',
+  MISSING: 'missing',
+};
+
+export const createUserDocSequencer = ({
+  planAction,
+  submitWrite,
+  readCache,
+  onChangeError,
+}) => {
+  let uid = null;
+  let existence = EXISTENCE.UNKNOWN;
+  let planningDoc = null;
+  let queue = [];
+  let unsettledCount = 0;
+  let generation = 0;
+  let lifecycleEpoch = 0;
+  let rebaseRequestSequence = 0;
+  let activeRebaseRequestToken = null;
+  let draining = false;
+  let disposed = false;
+
+  // Clears the listener/planning epoch: existence, the planning document, the
+  // pending queue, and any in-flight rebase. Deliberately leaves write-identity
+  // state (`unsettledCount`, `lifecycleEpoch`) alone so already-submitted writes
+  // still report their eventual outcome.
+  const resetPlanningState = () => {
+    existence = EXISTENCE.UNKNOWN;
+    planningDoc = null;
+    queue = [];
+    generation += 1;
+    activeRebaseRequestToken = null;
+  };
+
+  const reset = () => {
+    resetPlanningState();
+    unsettledCount = 0;
+    lifecycleEpoch += 1;
+  };
+
+  const reportError = (error, fallbackCode) => {
+    onChangeError(
+      (error && error.code) || fallbackCode,
+      (error && error.message) || String(error),
+    );
+  };
+
+  const applyCacheResult = (captured, result) => {
+    if (activeRebaseRequestToken !== captured.requestToken) {
+      return;
+    }
+    activeRebaseRequestToken = null;
+    if (
+      disposed ||
+      lifecycleEpoch !== captured.lifecycleEpoch ||
+      uid !== captured.uid ||
+      generation !== captured.generation
+    ) {
+      return;
+    }
+    if (captured.requireIdle && unsettledCount !== 0) {
+      // A pending write will schedule the next rebase, which drains.
+      return;
+    }
+    if (result) {
+      if (result.exists) {
+        existence = EXISTENCE.EXISTS;
+        planningDoc = result.data || {};
+      } else {
+        existence = EXISTENCE.MISSING;
+        planningDoc = null;
+      }
+    }
+    // Drain even when the cache read failed: actions held back during the
+    // rebase must not stall forever.
+    drain();
+  };
+
+  const scheduleRebase = ({ requireIdle }) => {
+    if (disposed || uid == null) {
+      return;
+    }
+    const requestToken = ++rebaseRequestSequence;
+    const captured = {
+      uid,
+      generation,
+      lifecycleEpoch,
+      requireIdle,
+      requestToken,
+    };
+    activeRebaseRequestToken = requestToken;
+    Promise.resolve()
+      .then(() => readCache())
+      .then(
+        (result) => applyCacheResult(captured, result),
+        () => applyCacheResult(captured, null),
+      );
+  };
+
+  const trackWrite = (writePromise) => {
+    // These callbacks exist only for writes submitted by this JS runtime.
+    // Firestore-restored writes reconcile through snapshots after a reload,
+    // but their original Promise callbacks cannot be restored.
+    const writeEpoch = lifecycleEpoch;
+    const writeUid = uid;
+    unsettledCount += 1;
+    writePromise.then(
+      () => {
+        if (writeEpoch !== lifecycleEpoch) {
+          return;
+        }
+        unsettledCount -= 1;
+        if (unsettledCount === 0) {
+          scheduleRebase({ requireIdle: true });
+        }
+      },
+      (error) => {
+        if (writeEpoch === lifecycleEpoch) {
+          unsettledCount -= 1;
+          reportError(error, 'unknown');
+          scheduleRebase({ requireIdle: false });
+          return;
+        }
+        // Stale epoch: the unsettled bookkeeping was reset with the UID
+        // change. But Firestore can resume and reject this write after the
+        // originating user signed back in (offline queue survives UID
+        // round-trips), and that user must still hear about the failure.
+        if (!disposed && uid === writeUid) {
+          reportError(error, 'unknown');
+          scheduleRebase({ requireIdle: false });
+        }
+      },
+    );
+  };
+
+  const drain = () => {
+    if (draining || disposed) {
+      return;
+    }
+    draining = true;
+    try {
+      // While a rebase is in flight, planningDoc may still contain a rejected
+      // mutation; hold new actions until the corrective document lands.
+      while (
+        queue.length > 0 &&
+        existence !== EXISTENCE.UNKNOWN &&
+        activeRebaseRequestToken === null
+      ) {
+        const modify = queue.shift();
+
+        if (existence === EXISTENCE.MISSING) {
+          // Documented no-op: `change` never creates the user document.
+          continue;
+        }
+
+        let plan;
+        try {
+          plan = planAction({ modify, userDoc: planningDoc });
+        } catch (error) {
+          reportError(error, 'change/planning-failed');
+          continue;
+        }
+        if (!plan || plan.kind === 'noop') {
+          continue;
+        }
+        if (plan.kind === 'invalid') {
+          onChangeError(plan.reason, `Cannot apply change: ${plan.reason}`);
+          continue;
+        }
+
+        let writePromise;
+        try {
+          writePromise = submitWrite({ plan });
+        } catch (error) {
+          reportError(error, 'change/submit-failed');
+          continue;
+        }
+
+        generation += 1;
+        planningDoc = plan.expectedDoc;
+        trackWrite(writePromise);
+        if (plan.kind === 'atomic-transform') {
+          // Firestore's local view preserves transform semantics that are lost
+          // once encoded values (such as integer vs double) become plain JS.
+          scheduleRebase({ requireIdle: false });
+        }
+      }
+    } finally {
+      draining = false;
+    }
+  };
+
+  return {
+    setUid(nextUid) {
+      if (nextUid === uid) {
+        return;
+      }
+      uid = nextUid;
+      reset();
+    },
+
+    enqueue({ uid: actionUid, modify }) {
+      if (disposed) {
+        return;
+      }
+      if (actionUid !== uid || uid == null) {
+        onChangeError(
+          'change/uid-mismatch',
+          'Change action dropped: it was queued for a different user.',
+        );
+        return;
+      }
+      queue.push(modify);
+      drain();
+    },
+
+    handleSnapshot({ uid: snapshotUid, exists, fromCache, getData }) {
+      if (disposed || snapshotUid !== uid) {
+        return;
+      }
+
+      // While UNKNOWN, snapshots always apply; afterwards they are dropped
+      // whenever local writes or a rebase would be regressed by them.
+      if (
+        existence !== EXISTENCE.UNKNOWN &&
+        (unsettledCount > 0 || activeRebaseRequestToken !== null)
+      ) {
+        return;
+      }
+
+      if (exists) {
+        existence = EXISTENCE.EXISTS;
+        planningDoc = getData() || {};
+      } else if (!fromCache) {
+        existence = EXISTENCE.MISSING;
+        planningDoc = null;
+      }
+      drain();
+    },
+
+    handleListenerFailure({ uid: listenerUid }) {
+      if (disposed || listenerUid !== uid) {
+        return;
+      }
+
+      resetPlanningState();
+    },
+
+    dispose() {
+      disposed = true;
+      queue = [];
+      lifecycleEpoch += 1;
+    },
+
+    inspect() {
+      return {
+        uid,
+        existence,
+        queueLength: queue.length,
+        unsettledCount,
+        generation,
+        rebaseInFlight: activeRebaseRequestToken !== null,
+        planningDoc,
+      };
+    },
+  };
+};

--- a/src/json/session/pandasuite.json
+++ b/src/json/session/pandasuite.json
@@ -287,9 +287,9 @@
           }
         }
       },
-      "description": "Fires when a user data modification fails.",
+      "description": "Fires when a user data modification submitted by the current page fails. After a reload, Firestore-restored writes reconcile data without emitting this event.",
       "locale_description": {
-        "fr_FR": "Se déclenche quand une modification des données utilisateur échoue."
+        "fr_FR": "Se déclenche lorsqu’une modification des données utilisateur envoyée par la page courante échoue. Après un rechargement, les écritures restaurées par Firestore réconcilient les données sans déclencher cet événement."
       }
     }
   ],

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -1,33 +1,8 @@
 import React, { useContext, useEffect } from 'react';
 import PandaBridge from 'pandasuite-bridge';
 
-import { deleteDB, openDB } from 'idb';
-import { find } from 'lodash';
-
 import FirebaseBridgeContext from '../../FirebaseBridgeContext';
 import { toQueryableShape } from '../../hooks/useFirebaseWithBridge/collectionStorageAdapter.mjs';
-
-async function fixIndexDbBug() {
-  if (!window.indexedDB) {
-    return;
-  }
-  const databases = await window.indexedDB.databases();
-  const firestoreDb = find(databases, (db) => db.name.startsWith('firestore/'));
-
-  if (!firestoreDb) {
-    return;
-  }
-
-  const timeOut = setTimeout(async () => {
-    console.log('IndexedDB Safari Bug...', firestoreDb.name);
-    await deleteDB(firestoreDb.name);
-  }, 200);
-
-  const db = await openDB(firestoreDb.name);
-  await db.getAll('owner');
-  clearTimeout(timeOut);
-  db.close();
-}
 
 const Home = () => {
   const firebaseWithBridge = useContext(FirebaseBridgeContext);
@@ -42,8 +17,6 @@ const Home = () => {
     if (!isSession || !currentUser) {
       return undefined;
     }
-
-    fixIndexDbBug();
 
     const unsubscribe =
       currentUser &&

--- a/tests/changeActionController.test.mjs
+++ b/tests/changeActionController.test.mjs
@@ -57,6 +57,64 @@ test('controller queues during auth bootstrap and flushes when auth becomes read
   assert.equal(errors.length, 0);
 });
 
+test('controller waits for observer-synchronized auth before flushing changes', () => {
+  const applied = [];
+  const errors = [];
+  const scheduler = createFakeScheduler();
+  const controller = createChangeActionController({
+    applyChange: ({ user, modify }) => {
+      applied.push({ user, modify });
+    },
+    sendChangeError: (code, message) => {
+      errors.push({ code, message });
+    },
+    schedule: scheduler.schedule,
+    clearScheduled: scheduler.clearScheduled,
+  });
+
+  controller.handleIncomingChange({
+    auth: null,
+    payload: { property: '/queued', func: 'set', value: 1 },
+  });
+
+  const user = { uid: 'u1' };
+  const auth = { currentUser: user };
+  controller.handleIncomingChange({
+    auth,
+    payload: { property: '/during-sign-in', func: 'set', value: 2 },
+  });
+
+  assert.deepEqual(applied, []);
+
+  controller.syncAuth(auth);
+
+  assert.deepEqual(
+    applied.map(({ modify }) => modify.property),
+    ['/queued', '/during-sign-in'],
+  );
+  assert.deepEqual(errors, []);
+});
+
+test('controller discards a queued change when auth synchronizes a different user', () => {
+  const applied = [];
+  const controller = createChangeActionController({
+    applyChange: ({ user, modify }) => {
+      applied.push({ user, modify });
+    },
+    sendChangeError: () => {},
+  });
+
+  controller.handleIncomingChange({
+    auth: { currentUser: { uid: 'user-a' } },
+    payload: { property: '/profile/name', func: 'set', value: 'Alice' },
+  });
+
+  controller.syncAuth({ currentUser: { uid: 'user-b' } });
+  controller.syncAuth({ currentUser: { uid: 'user-a' } });
+
+  assert.deepEqual(applied, []);
+});
+
 test('controller keeps pending changes across transient signed-out and flushes when ready', () => {
   const applied = [];
   const errors = [];

--- a/tests/createChangeRuntime.test.mjs
+++ b/tests/createChangeRuntime.test.mjs
@@ -1,0 +1,240 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { JSONPointer, ModifyData } from '@beingenious/jsonpointer';
+
+import { subscribeToChangeAuth } from '../src/hooks/useFirebaseWithBridge/changeActionController.mjs';
+import { createChangeRuntime } from '../src/hooks/useFirebaseWithBridge/createChangeRuntime.mjs';
+import { FakeFieldPath, FakeFieldValue as FieldValue } from './firestoreFakes.mjs';
+
+const settle = () => new Promise((resolve) => setImmediate(resolve));
+
+const createFakeFirestore = () => {
+  const state = {
+    listeners: new Map(), // uid -> { onNext, onError }
+    subscriptions: [],
+    updates: [],
+    sets: [],
+    pendingWrites: [],
+    unsubscribed: [],
+    cacheResult: { exists: true, data: () => ({}) },
+  };
+  const firestore = {
+    collection: () => ({
+      doc: (uid) => ({
+        onSnapshot: (options, onNext, onError) => {
+          state.listeners.set(uid, { onNext, onError });
+          state.subscriptions.push(uid);
+          return () => state.unsubscribed.push(uid);
+        },
+        get: ({ source }) => {
+          assert.equal(source, 'cache');
+          return Promise.resolve(state.cacheResult);
+        },
+        update: (...args) => {
+          state.updates.push({ uid, args });
+          return new Promise((resolve, reject) => {
+            state.pendingWrites.push({ resolve, reject });
+          });
+        },
+        set: (...args) => {
+          state.sets.push({ uid, args });
+          return new Promise((resolve, reject) => {
+            state.pendingWrites.push({ resolve, reject });
+          });
+        },
+      }),
+    }),
+    runTransaction: () => {
+      throw new Error('runTransaction must never be called');
+    },
+  };
+  const emitSnapshot = (uid, { exists, fromCache, data }) => {
+    state.listeners.get(uid).onNext({
+      exists,
+      metadata: { fromCache, hasPendingWrites: false },
+      data: () => data,
+    });
+  };
+  const emitListenerError = (uid, error) => {
+    state.listeners.get(uid).onError(error);
+  };
+  return { firestore, state, emitSnapshot, emitListenerError };
+};
+
+test('runtime rebases transforms locally without any transaction', async () => {
+  const { firestore, state, emitSnapshot } = createFakeFirestore();
+  const errors = [];
+  const runtime = createChangeRuntime({
+    firestore,
+    FieldValue,
+    FieldPath: FakeFieldPath,
+    JSONPointer,
+    ModifyData,
+    sendChangeError: (code, message) => errors.push({ code, message }),
+    language: 'en_US',
+  });
+
+  runtime.setUser({ uid: 'u1' });
+  emitSnapshot('u1', { exists: true, fromCache: false, data: { count: 1 } });
+
+  runtime.enqueue({
+    uid: 'u1',
+    modify: { property: '/count', func: 'inc', value: 1 },
+  });
+  runtime.enqueue({
+    uid: 'u1',
+    modify: { property: '/count', func: 'inc', value: 1 },
+  });
+  await settle();
+
+  assert.equal(state.updates.length, 2);
+  assert.deepEqual(state.updates[0].args, [
+    'count',
+    { real: 'increment', n: 1 },
+  ]);
+  // Both writes stay atomic; the second only waits for the local cache view.
+  assert.deepEqual(state.updates[1].args, [
+    'count',
+    { real: 'increment', n: 1 },
+  ]);
+  assert.deepEqual(errors, []);
+});
+
+test('user switch unsubscribes the old listener and isolates queues', () => {
+  const { firestore, state, emitSnapshot } = createFakeFirestore();
+  const runtime = createChangeRuntime({
+    firestore,
+    FieldValue,
+    FieldPath: FakeFieldPath,
+    JSONPointer,
+    ModifyData,
+    sendChangeError: () => {},
+    language: 'en_US',
+  });
+
+  runtime.setUser({ uid: 'u1' });
+  runtime.enqueue({
+    uid: 'u1',
+    modify: { property: '/a', func: 'set', value: 1 },
+  });
+
+  runtime.setUser({ uid: 'u2' });
+  assert.deepEqual(state.unsubscribed, ['u1']);
+
+  emitSnapshot('u2', { exists: true, fromCache: false, data: {} });
+  assert.equal(state.updates.length, 0, 'u1 action must not reach u2');
+
+  runtime.dispose();
+  assert.deepEqual(state.unsubscribed, ['u1', 'u2']);
+});
+
+test('an ID-token refresh restores the same-UID listener after a terminal error', () => {
+  const { firestore, state, emitSnapshot, emitListenerError } =
+    createFakeFirestore();
+  const errors = [];
+  const runtime = createChangeRuntime({
+    firestore,
+    FieldValue,
+    FieldPath: FakeFieldPath,
+    JSONPointer,
+    ModifyData,
+    sendChangeError: (code, message) => errors.push({ code, message }),
+    language: 'en_US',
+  });
+
+  const user = { uid: 'u1' };
+  let emitIdTokenChanged;
+  subscribeToChangeAuth({
+    auth: {
+      currentUser: user,
+      onIdTokenChanged: (listener) => {
+        emitIdTokenChanged = listener;
+        return () => {};
+      },
+    },
+    setUser: (nextUser) => runtime.setUser(nextUser),
+    syncAuth: () => {},
+  });
+
+  runtime.enqueue({
+    uid: 'u1',
+    modify: { property: '/queued', func: 'set', value: true },
+  });
+
+  const listenerError = Object.assign(new Error('denied'), {
+    code: 'permission-denied',
+  });
+  emitListenerError('u1', listenerError);
+
+  assert.deepEqual(errors, [{ code: 'permission-denied', message: 'denied' }]);
+  assert.equal(state.updates.length, 0);
+
+  runtime.enqueue({
+    uid: 'u1',
+    modify: { property: '/blocked', func: 'set', value: true },
+  });
+  assert.equal(errors.at(-1).code, 'change/listener-unavailable');
+
+  emitIdTokenChanged(user);
+  assert.deepEqual(state.subscriptions, ['u1', 'u1']);
+  emitSnapshot('u1', { exists: true, fromCache: false, data: {} });
+  runtime.enqueue({
+    uid: 'u1',
+    modify: { property: '/fresh', func: 'set', value: true },
+  });
+
+  assert.equal(state.updates.length, 1);
+  assert.deepEqual(state.updates[0].args, ['fresh', true]);
+});
+
+test('a terminal listener error preserves failures from already-submitted writes', async () => {
+  const { firestore, state, emitSnapshot, emitListenerError } =
+    createFakeFirestore();
+  const errors = [];
+  const runtime = createChangeRuntime({
+    firestore,
+    FieldValue,
+    FieldPath: FakeFieldPath,
+    JSONPointer,
+    ModifyData,
+    sendChangeError: (code, message) => errors.push({ code, message }),
+    language: 'en_US',
+  });
+
+  runtime.setUser({ uid: 'u1' });
+  emitSnapshot('u1', { exists: true, fromCache: false, data: {} });
+  runtime.enqueue({
+    uid: 'u1',
+    modify: { property: '/a', func: 'set', value: 1 },
+  });
+  runtime.enqueue({
+    uid: 'u1',
+    modify: { property: '/b', func: 'set', value: 2 },
+  });
+  assert.equal(state.pendingWrites.length, 2);
+
+  emitListenerError(
+    'u1',
+    Object.assign(new Error('listener denied'), {
+      code: 'permission-denied',
+    }),
+  );
+  state.pendingWrites[0].reject(
+    Object.assign(new Error('write a denied'), {
+      code: 'permission-denied',
+    }),
+  );
+  state.pendingWrites[1].reject(
+    Object.assign(new Error('write b denied'), {
+      code: 'permission-denied',
+    }),
+  );
+  await settle();
+
+  assert.deepEqual(errors, [
+    { code: 'permission-denied', message: 'listener denied' },
+    { code: 'permission-denied', message: 'write a denied' },
+    { code: 'permission-denied', message: 'write b denied' },
+  ]);
+});

--- a/tests/emulator/conflictContract.test.mjs
+++ b/tests/emulator/conflictContract.test.mjs
@@ -1,0 +1,508 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import _ from 'lodash';
+
+import {
+  encodeIdKey,
+  toQueryableShape,
+} from '../../src/hooks/useFirebaseWithBridge/collectionStorageAdapter.mjs';
+import {
+  PROJECT_ID,
+  createEmulatorClient,
+  createRuntimeHarness,
+  deleteAllApps,
+  waitFor,
+} from './helpers.mjs';
+
+const seedClient = createEmulatorClient();
+const seed = (uid, data) =>
+  seedClient.firestore.collection('users').doc(uid).set(data);
+const seedRawFields = async (uid, fields) => {
+  const response = await fetch(
+    `http://127.0.0.1:8080/v1/projects/${PROJECT_ID}/databases/(default)/documents/users/${encodeURIComponent(uid)}`,
+    {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ fields }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to seed raw Firestore fields: ${response.status}`);
+  }
+};
+
+test.after(async () => {
+  await deleteAllApps();
+});
+
+test('two clients incrementing through change actions produce the sum', async () => {
+  const uid = 'inc-sum';
+  await seed(uid, { count: 0 });
+  const a = createRuntimeHarness(uid);
+  const b = createRuntimeHarness(uid);
+
+  a.change({ property: '/count', func: 'inc', value: 2 });
+  b.change({ property: '/count', func: 'inc', value: 3 });
+
+  await waitFor(async () => (await a.serverDoc())?.count === 5);
+  assert.deepEqual(a.errors, []);
+  assert.deepEqual(b.errors, []);
+});
+
+test('concurrent writes to different fields are both retained', async () => {
+  const uid = 'diff-fields';
+  await seed(uid, { a: 1, b: 1 });
+  const a = createRuntimeHarness(uid);
+  const b = createRuntimeHarness(uid);
+
+  a.change({ property: '/a', func: 'set', value: 2 });
+  b.change({ property: '/b', func: 'set', value: 3 });
+
+  await waitFor(async () => {
+    const doc = await a.serverDoc();
+    return doc?.a === 2 && doc?.b === 3;
+  });
+});
+
+test('serverDoc ignores pending writer overlays until the server acknowledges them', async () => {
+  const uid = 'server-observer';
+  await seed(uid, { x: 0 });
+  const a = createRuntimeHarness(uid);
+  await waitFor(async () => (await a.serverDoc())?.x === 0);
+  await waitFor(async () => (await a.localDoc())?.x === 0);
+
+  await a.client.firestore.disableNetwork();
+  try {
+    a.change({ property: '/x', func: 'set', value: 1 });
+    await waitFor(async () => (await a.localDoc())?.x === 1);
+
+    assert.equal((await a.serverDoc())?.x, 0);
+  } finally {
+    await a.client.firestore.enableNetwork();
+  }
+});
+
+test('offline array transforms rebase from Firestore numeric types before later actions', async () => {
+  const uid = 'numeric-array-rebase';
+  await seedRawFields(uid, {
+    arr: {
+      arrayValue: {
+        values: [
+          {
+            mapValue: {
+              fields: { v: { doubleValue: 1 } },
+            },
+          },
+        ],
+      },
+    },
+  });
+  const a = createRuntimeHarness(uid);
+  await waitFor(async () => (await a.localDoc())?.arr?.length === 1);
+
+  await a.client.firestore.disableNetwork();
+  try {
+    // The SDK encodes this operand as integerValue: 1, so Firestore's local
+    // arrayUnion keeps it distinct from the REST-seeded doubleValue: 1.
+    a.change({ property: '/arr', func: 'add', value: { v: 1 } });
+    a.change({
+      property: '/arr/@getByIndex:1/marked',
+      func: 'set',
+      value: true,
+    });
+
+    const local = await waitFor(async () => {
+      const doc = await a.localDoc();
+      return doc?.arr?.[1]?.v === 1 && doc.arr[1].marked === true ? doc : null;
+    });
+    assert.deepEqual(local.arr, [{ v: 1 }, { v: 1, marked: true }]);
+  } finally {
+    await a.client.firestore.enableNetwork();
+  }
+});
+
+test('concurrent rewrites of one plain array are last-write-wins', async () => {
+  const uid = 'array-lww';
+  const initialArr = [{ id: '1', v: 1 }, { id: '2', v: 2 }];
+  await seed(uid, { arr: initialArr });
+  const a = createRuntimeHarness(uid);
+  const b = createRuntimeHarness(uid);
+  await waitFor(async () => (await a.serverDoc()) !== null);
+  await waitFor(async () => {
+    const [aDoc, bDoc] = await Promise.all([a.localDoc(), b.localDoc()]);
+    return _.isEqual(aDoc?.arr, initialArr) && _.isEqual(bDoc?.arr, initialArr);
+  });
+
+  await a.client.firestore.disableNetwork();
+  await b.client.firestore.disableNetwork();
+
+  // Nested mutations in a plain array rewrite the whole array (spec mapping).
+  a.change({ property: '/arr/@find:id|eq|1/v', func: 'set', value: 9 });
+  b.change({ property: '/arr/@find:id|eq|2/v', func: 'set', value: 8 });
+
+  await a.client.firestore.enableNetwork();
+  await waitFor(async () => (await a.serverDoc())?.arr?.[0]?.v === 9);
+  await b.client.firestore.enableNetwork();
+
+  // B's rewrite arrives last and wins the whole array; A's edit is lost.
+  await waitFor(async () => (await a.serverDoc())?.arr?.[1]?.v === 8);
+  const doc = await a.serverDoc();
+  assert.deepEqual(doc.arr, [{ id: '1', v: 1 }, { id: '2', v: 8 }]);
+});
+
+test('plain-array delbyid removes the exact local row; a concurrent change prevents the match', async () => {
+  const uid = 'delbyid-stale';
+  const initialArr = [{ id: '1', v: 1 }];
+  await seed(uid, { arr: initialArr });
+  const a = createRuntimeHarness(uid);
+  const b = createRuntimeHarness(uid);
+  await waitFor(async () => (await a.serverDoc()) !== null);
+  await waitFor(async () => _.isEqual((await a.localDoc())?.arr, initialArr));
+
+  await a.client.firestore.disableNetwork();
+
+  // B changes the row first (whole-array rewrite), acknowledged by the server.
+  b.change({ property: '/arr/@find:id|eq|1/v', func: 'set', value: 2 });
+  await waitFor(async () => (await b.serverDoc())?.arr?.[0]?.v === 2);
+
+  // A deletes based on its stale local row {id:'1', v:1}: arrayRemove misses.
+  a.change({ property: '/arr', func: 'delbyid', value: '1' });
+  await a.client.firestore.enableNetwork();
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 500);
+  });
+  const doc = await b.serverDoc();
+  assert.deepEqual(doc.arr, [{ id: '1', v: 2 }], 'stale delete must be a no-op');
+});
+
+test('Collection membership and row commit atomically in one write', async () => {
+  const uid = 'collection-atomic';
+  await seed(uid, { items: { type: 'Collection', order: [], valueById: {} } });
+  const a = createRuntimeHarness(uid);
+
+  a.change({ property: '/items', func: 'add', value: { id: '1', v: 1 } });
+
+  const doc = await waitFor(async () => {
+    const d = await a.serverDoc();
+    return d?.items?.order?.length === 1 ? d : null;
+  });
+  // Same server document version holds both membership and the row.
+  assert.deepEqual(doc.items.order, ['1']);
+  const [rowKey] = Object.keys(doc.items.valueById);
+  assert.deepEqual(doc.items.valueById[rowKey], { id: '1', v: 1 });
+});
+
+test('an identical canonical add does not overwrite another row changed remotely', async () => {
+  const uid = 'collection-identical-add';
+  const initialItems = {
+    type: 'Collection',
+    order: ['1', '2'],
+    valueById: {
+      [encodeIdKey('1')]: { id: '1', v: 1 },
+      [encodeIdKey('2')]: { id: '2', v: 1 },
+    },
+  };
+  await seed(uid, { items: initialItems });
+  const a = createRuntimeHarness(uid);
+  const b = createRuntimeHarness(uid);
+  await waitFor(async () => _.isEqual((await a.localDoc())?.items, initialItems));
+
+  await a.client.firestore.disableNetwork();
+  let networkDisabled = true;
+  try {
+    b.change({ property: '/items/@getById:2/v', func: 'set', value: 2 });
+    await waitFor(
+      async () =>
+        (await b.serverDoc())?.items?.valueById?.[encodeIdKey('2')]?.v === 2,
+    );
+
+    a.change({ property: '/items', func: 'add', value: { id: '1', v: 1 } });
+    await a.client.firestore.enableNetwork();
+    networkDisabled = false;
+    await a.client.firestore.waitForPendingWrites();
+
+    const doc = await a.serverDoc();
+    assert.equal(doc.items.valueById[encodeIdKey('2')].v, 2);
+  } finally {
+    if (networkDisabled) {
+      await a.client.firestore.enableNetwork();
+    }
+  }
+});
+
+test('a canonical delbyid removes a row added while the deleting client was offline', async () => {
+  const uid = 'collection-stale-delete';
+  const emptyItems = { type: 'Collection', order: [], valueById: {} };
+  await seed(uid, { items: emptyItems });
+  const a = createRuntimeHarness(uid);
+  const b = createRuntimeHarness(uid);
+  await waitFor(async () => _.isEqual((await a.localDoc())?.items, emptyItems));
+
+  await a.client.firestore.disableNetwork();
+  let networkDisabled = true;
+  try {
+    b.change({ property: '/items', func: 'add', value: { id: '1', v: 1 } });
+    await waitFor(
+      async () => (await b.serverDoc())?.items?.order?.includes('1'),
+    );
+
+    a.change({ property: '/items', func: 'delbyid', value: '1' });
+    await a.client.firestore.enableNetwork();
+    networkDisabled = false;
+    await a.client.firestore.waitForPendingWrites();
+
+    const doc = await a.serverDoc();
+    assert.deepEqual(doc.items.order, []);
+    assert.equal(encodeIdKey('1') in doc.items.valueById, false);
+  } finally {
+    if (networkDisabled) {
+      await a.client.firestore.enableNetwork();
+    }
+  }
+});
+
+test('a canonical delbyid removes a row stored under a legacy raw key', async () => {
+  const uid = 'collection-raw-key-delete';
+  const rawKey = 'foo';
+  await seed(uid, {
+    items: {
+      type: 'Collection',
+      order: [rawKey],
+      valueById: { [rawKey]: { id: rawKey, v: 1 } },
+    },
+  });
+  const a = createRuntimeHarness(uid);
+  await waitFor(async () => (await a.localDoc())?.items?.order?.[0] === rawKey);
+
+  a.change({ property: '/items', func: 'delbyid', value: rawKey });
+
+  const doc = await waitFor(async () => {
+    const serverDoc = await a.serverDoc();
+    return serverDoc?.items?.order?.length === 0 ? serverDoc : null;
+  });
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(doc.items.valueById, rawKey),
+    false,
+  );
+  assert.deepEqual(a.errors, []);
+});
+
+test('a stale canonical delbyid removes numeric membership added remotely', async () => {
+  const uid = 'collection-stale-numeric-delete';
+  const rowKey = encodeIdKey('1');
+  const emptyItems = { type: 'Collection', order: [], valueById: {} };
+  await seed(uid, { items: emptyItems });
+  const a = createRuntimeHarness(uid);
+  await waitFor(async () => _.isEqual((await a.localDoc())?.items, emptyItems));
+
+  await a.client.firestore.disableNetwork();
+  let networkDisabled = true;
+  try {
+    await seed(uid, {
+      items: {
+        type: 'Collection',
+        order: [1],
+        valueById: { [rowKey]: { id: '1', v: 1 } },
+      },
+    });
+
+    a.change({ property: '/items', func: 'delbyid', value: '1' });
+    await a.client.firestore.enableNetwork();
+    networkDisabled = false;
+    await a.client.firestore.waitForPendingWrites();
+
+    const doc = await a.serverDoc();
+    assert.deepEqual(doc.items.order, []);
+    assert.equal(rowKey in doc.items.valueById, false);
+  } finally {
+    if (networkDisabled) {
+      await a.client.firestore.enableNetwork();
+    }
+  }
+});
+
+test('incrementing a missing canonical row field preserves another remote row update', async () => {
+  const uid = 'collection-missing-field-increment';
+  const initialItems = {
+    type: 'Collection',
+    order: ['1', '2'],
+    valueById: {
+      [encodeIdKey('1')]: { id: '1' },
+      [encodeIdKey('2')]: { id: '2', v: 1 },
+    },
+  };
+  await seed(uid, { items: initialItems });
+  const a = createRuntimeHarness(uid);
+  const b = createRuntimeHarness(uid);
+  await waitFor(async () => _.isEqual((await a.localDoc())?.items, initialItems));
+
+  await a.client.firestore.disableNetwork();
+  let networkDisabled = true;
+  try {
+    b.change({ property: '/items/@getById:2/v', func: 'set', value: 2 });
+    await waitFor(
+      async () =>
+        (await b.serverDoc())?.items?.valueById?.[encodeIdKey('2')]?.v === 2,
+    );
+
+    a.change({
+      property: '/items/@getById:1/score',
+      func: 'inc',
+      value: 2,
+    });
+    await a.client.firestore.enableNetwork();
+    networkDisabled = false;
+    await a.client.firestore.waitForPendingWrites();
+
+    const doc = await a.serverDoc();
+    assert.equal(doc.items.valueById[encodeIdKey('1')].score, 2);
+    assert.equal(doc.items.valueById[encodeIdKey('2')].v, 2);
+  } finally {
+    if (networkDisabled) {
+      await a.client.firestore.enableNetwork();
+    }
+  }
+});
+
+test('concurrent same-ID delete then add resolves to the last complete mutation', async () => {
+  const uid = 'same-id-add-delete';
+  const enc = (await import('../../src/hooks/useFirebaseWithBridge/collectionStorageAdapter.mjs')).encodeIdKey;
+  const initialItems = {
+    type: 'Collection',
+    order: ['1'],
+    valueById: { [enc('1')]: { id: '1', v: 1 } },
+  };
+  await seed(uid, { items: initialItems });
+  const a = createRuntimeHarness(uid);
+  const b = createRuntimeHarness(uid);
+  await waitFor(async () => (await a.serverDoc()) !== null);
+  await waitFor(async () => {
+    const [aDoc, bDoc] = await Promise.all([a.localDoc(), b.localDoc()]);
+    return (
+      _.isEqual(aDoc?.items, initialItems) && _.isEqual(bDoc?.items, initialItems)
+    );
+  });
+
+  await a.client.firestore.disableNetwork();
+  await b.client.firestore.disableNetwork();
+
+  a.change({ property: '/items', func: 'delbyid', value: '1' });
+  b.change({ property: '/items', func: 'add', value: { id: '1', v: 5 } });
+
+  await a.client.firestore.enableNetwork();
+  await waitFor(async () => ((await a.serverDoc())?.items?.order ?? []).length === 0);
+  await b.client.firestore.enableNetwork();
+
+  // Add arrived last: membership and a complete row are back.
+  const doc = await waitFor(async () => {
+    const d = await a.serverDoc();
+    return d?.items?.order?.length === 1 ? d : null;
+  });
+  assert.deepEqual(doc.items.valueById[enc('1')], { id: '1', v: 5 });
+});
+
+test('a delete racing a targeted row update stays absent from the queryable Collection', async () => {
+  const uid = 'remove-wins';
+  const enc = (await import('../../src/hooks/useFirebaseWithBridge/collectionStorageAdapter.mjs')).encodeIdKey;
+  const initialItems = {
+    type: 'Collection',
+    order: ['1'],
+    valueById: { [enc('1')]: { id: '1', v: 1 } },
+  };
+  await seed(uid, { items: initialItems });
+  const a = createRuntimeHarness(uid);
+  const b = createRuntimeHarness(uid);
+  await waitFor(async () => (await a.serverDoc()) !== null);
+  await waitFor(async () => _.isEqual((await a.localDoc())?.items, initialItems));
+
+  await a.client.firestore.disableNetwork();
+
+  // B deletes the row, acknowledged.
+  b.change({ property: '/items', func: 'delbyid', value: '1' });
+  await waitFor(async () => ((await b.serverDoc())?.items?.order ?? ['x']).length === 0);
+
+  // A's targeted update of the now-deleted row lands afterwards.
+  a.change({ property: '/items/@find:id|eq|1/v', func: 'set', value: 7 });
+  await a.client.firestore.enableNetwork();
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 500);
+  });
+  const doc = await b.serverDoc();
+  assert.deepEqual(doc.items.order, [], 'order stays authoritative: remove wins');
+  const queryable = toQueryableShape(doc);
+  assert.deepEqual(
+    _.get(queryable, 'items.value', []).filter((row) => row.id === '1'),
+    [],
+    'orphan valueById entries are not projected',
+  );
+});
+
+test('a Security Rules rejection emits onChangeError and is removed without transitive rollback', async () => {
+  const uid = 'rules-rejection';
+  await seed(uid, { ok: 0 });
+  const a = createRuntimeHarness(uid);
+  await waitFor(async () => (await a.serverDoc()) !== null);
+
+  a.change({ property: '/forbidden', func: 'set', value: true });
+  a.change({ property: '/ok', func: 'inc', value: 1 });
+
+  await waitFor(() => a.errors.some((e) => e.code === 'permission-denied'));
+  await waitFor(async () => (await a.serverDoc())?.ok === 1);
+  const doc = await a.serverDoc();
+  assert.equal('forbidden' in doc, false, 'rejected mutation removed');
+  assert.equal(doc.ok, 1, 'independent later write is not rolled back');
+});
+
+test('a remote deletion makes queued targeted updates fail with not-found', async () => {
+  const uid = 'remote-deletion';
+  await seed(uid, { x: 0 });
+  const a = createRuntimeHarness(uid);
+  await waitFor(async () => (await a.serverDoc()) !== null);
+  await waitFor(async () => (await a.localDoc())?.x === 0);
+
+  await a.client.firestore.disableNetwork();
+  a.change({ property: '/x', func: 'set', value: 1 });
+
+  await seedClient.firestore.collection('users').doc(uid).delete();
+  await a.client.firestore.enableNetwork();
+
+  await waitFor(() => a.errors.some((e) => e.code === 'not-found'));
+});
+
+test('a server-confirmed missing document turns change actions into silent no-ops', async () => {
+  const uid = 'known-missing';
+  const a = createRuntimeHarness(uid); // never seeded: first non-cache snapshot confirms missing
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 500);
+  });
+  a.change({ property: '/a', func: 'set', value: 1 });
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 500);
+  });
+  assert.equal(await a.serverDoc(), null, 'change never creates the user document');
+  assert.deepEqual(a.errors, [], 'documented no-op, not an error');
+});
+
+test('a literal Firestore path metacharacter is writable through change actions', async () => {
+  const uid = 'literal-path-metacharacter';
+  const key = 'score[kg]';
+  await seed(uid, { profile: { [key]: 1 } });
+  const a = createRuntimeHarness(uid);
+  await waitFor(async () => (await a.localDoc())?.profile?.[key] === 1);
+
+  a.change({
+    property: [
+      { func: 'getKey', value: 'profile' },
+      { func: 'getKey', value: key },
+    ],
+    func: 'set',
+    value: 2,
+  });
+
+  await waitFor(async () => (await a.serverDoc())?.profile?.[key] === 2);
+  assert.deepEqual(a.errors, []);
+});

--- a/tests/emulator/firebase.json
+++ b/tests/emulator/firebase.json
@@ -1,0 +1,13 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": false
+    }
+  }
+}

--- a/tests/emulator/firestore.rules
+++ b/tests/emulator/firestore.rules
@@ -1,0 +1,10 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{uid} {
+      allow read: if true;
+      allow delete: if true;
+      allow create, update: if !('forbidden' in request.resource.data);
+    }
+  }
+}

--- a/tests/emulator/helpers.mjs
+++ b/tests/emulator/helpers.mjs
@@ -1,0 +1,108 @@
+import app from 'firebase/compat/app';
+import 'firebase/compat/firestore';
+
+import { JSONPointer, ModifyData } from '@beingenious/jsonpointer';
+
+import { createChangeRuntime } from '../../src/hooks/useFirebaseWithBridge/createChangeRuntime.mjs';
+
+export const PROJECT_ID = 'demo-panda-optimistic';
+const HOST = '127.0.0.1';
+const PORT = 8080;
+
+let appCount = 0;
+const runtimes = new Set();
+
+export const createEmulatorClient = () => {
+  appCount += 1;
+  const client = app.initializeApp({ projectId: PROJECT_ID }, `client-${appCount}`);
+  const firestore = client.firestore();
+  firestore.useEmulator(HOST, PORT);
+  return {
+    app: client,
+    firestore,
+    FieldValue: app.firestore.FieldValue,
+    FieldPath: app.firestore.FieldPath,
+  };
+};
+
+export const clearEmulatorData = async () => {
+  const response = await fetch(
+    `http://${HOST}:${PORT}/emulator/v1/projects/${PROJECT_ID}/databases/(default)/documents`,
+    { method: 'DELETE' },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to clear emulator data: ${response.status}`);
+  }
+};
+
+export const deleteAllApps = async () => {
+  for (const runtime of runtimes) {
+    runtime.dispose();
+  }
+  runtimes.clear();
+  for (const firebaseApp of app.apps) {
+    await firebaseApp.delete();
+  }
+};
+
+export const waitFor = async (predicate, { timeout = 8000, interval = 25 } = {}) => {
+  const start = Date.now();
+  for (;;) {
+    const value = await predicate();
+    if (value) {
+      return value;
+    }
+    if (Date.now() - start > timeout) {
+      throw new Error('waitFor: condition not met within timeout');
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, interval);
+    });
+  }
+};
+
+export const createRuntimeHarness = (uid) => {
+  const client = createEmulatorClient();
+  const observer = createEmulatorClient();
+  client.firestore.runTransaction = () => {
+    throw new Error('runTransaction must never be called by the change path');
+  };
+
+  const errors = [];
+  const runtime = createChangeRuntime({
+    firestore: client.firestore,
+    FieldValue: client.FieldValue,
+    FieldPath: client.FieldPath,
+    JSONPointer,
+    ModifyData,
+    sendChangeError: (code, message) => errors.push({ code, message }),
+    language: 'en_US',
+  });
+  runtimes.add(runtime);
+  runtime.setUser({ uid });
+
+  const docRef = client.firestore.collection('users').doc(uid);
+  const observerDocRef = observer.firestore.collection('users').doc(uid);
+  return {
+    client,
+    runtime,
+    errors,
+    docRef,
+    change: (modify) => runtime.enqueue({ uid, modify }),
+    localDoc: async () => {
+      try {
+        const snapshot = await docRef.get({ source: 'cache' });
+        return snapshot.exists ? snapshot.data() : null;
+      } catch (error) {
+        if (error?.code === 'unavailable') {
+          return null;
+        }
+        throw error;
+      }
+    },
+    serverDoc: async () => {
+      const snapshot = await observerDocRef.get({ source: 'server' });
+      return snapshot.exists ? snapshot.data() : null;
+    },
+  };
+};

--- a/tests/emulator/smoke.test.mjs
+++ b/tests/emulator/smoke.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  clearEmulatorData,
+  createEmulatorClient,
+  deleteAllApps,
+} from './helpers.mjs';
+
+test('two clients incrementing the same number produce the sum of both transforms', async () => {
+  await clearEmulatorData();
+  const a = createEmulatorClient();
+  const b = createEmulatorClient();
+  try {
+    const refA = a.firestore.collection('users').doc('smoke-user');
+    const refB = b.firestore.collection('users').doc('smoke-user');
+
+    await refA.set({ count: 0 });
+    await Promise.all([
+      refA.update({ count: a.FieldValue.increment(2) }),
+      refB.update({ count: b.FieldValue.increment(3) }),
+    ]);
+
+    const snapshot = await refA.get();
+    assert.equal(snapshot.data().count, 5);
+  } finally {
+    await deleteAllApps();
+  }
+});

--- a/tests/firestoreChangeWriter.test.mjs
+++ b/tests/firestoreChangeWriter.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createFirestoreChangeWriter } from '../src/hooks/useFirebaseWithBridge/firestoreChangeWriter.mjs';
+import { FIELD_PATH_UPDATES } from '../src/hooks/useFirebaseWithBridge/modifyDataAdapter.mjs';
+import { plannerFieldValue } from '../src/hooks/useFirebaseWithBridge/mutationSentinels.mjs';
+import { FakeFieldPath, FakeFieldValue } from './firestoreFakes.mjs';
+
+const createHarness = () => {
+  const calls = [];
+  const updatePromise = Promise.resolve('updated');
+  const docRef = {
+    update: (...args) => {
+      calls.push({ method: 'update', args });
+      return updatePromise;
+    },
+  };
+  const writer = createFirestoreChangeWriter({
+    FieldValue: FakeFieldValue,
+    FieldPath: FakeFieldPath,
+  });
+  return { writer, docRef, calls, updatePromise };
+};
+
+test('targeted writes become one varargs update call with converted sentinels', async () => {
+  const { writer, docRef, calls } = createHarness();
+  await writer.submit({
+    docRef,
+    plan: {
+      kind: 'atomic-transform',
+      update: {
+        count: plannerFieldValue.increment(2),
+        name: 'bob',
+      },
+      expectedDoc: {},
+    },
+  });
+
+  const update = calls[0];
+  assert.equal(update.method, 'update');
+  assert.deepEqual(update.args, [
+    'count',
+    { real: 'increment', n: 2 },
+    'name',
+    'bob',
+  ]);
+});
+
+test('FIELD_PATH_UPDATES convert branded sentinels, preserve literal data, and return the update promise', async () => {
+  const literal = { __pandaFsSentinel: 'delete', keep: 1 };
+  const { writer, docRef, calls, updatePromise } = createHarness();
+  const submitted = writer.submit({
+    docRef,
+    plan: {
+      kind: 'targeted-write',
+      update: {
+        [FIELD_PATH_UPDATES]: [
+          {
+            segments: ['profile', 'a.b'],
+            value: plannerFieldValue.increment(2),
+          },
+          { segments: ['profile', 'literal'], value: literal },
+        ],
+      },
+      expectedDoc: {},
+    },
+  });
+  assert.strictEqual(submitted, updatePromise);
+  await submitted;
+
+  const update = calls[0];
+  assert.equal(update.method, 'update');
+  assert.ok(update.args[0] instanceof FakeFieldPath);
+  assert.deepEqual(update.args[0].segments, ['profile', 'a.b']);
+  assert.deepEqual(update.args[1], { real: 'increment', n: 2 });
+  assert.ok(update.args[2] instanceof FakeFieldPath);
+  assert.deepEqual(update.args[2].segments, ['profile', 'literal']);
+  assert.strictEqual(update.args[3], literal);
+});
+
+test('an empty update resolves without calling Firestore', async () => {
+  const { writer, docRef, calls } = createHarness();
+  await writer.submit({
+    docRef,
+    plan: { kind: 'targeted-write', update: {}, expectedDoc: {} },
+  });
+  assert.equal(calls.length, 0);
+});

--- a/tests/firestoreFakes.mjs
+++ b/tests/firestoreFakes.mjs
@@ -1,0 +1,14 @@
+// Shared unit-test doubles for the Firestore FieldPath/FieldValue contract
+// used by the change writer and runtime tests.
+export class FakeFieldPath {
+  constructor(...segments) {
+    this.segments = segments;
+  }
+}
+
+export const FakeFieldValue = {
+  increment: (n) => ({ real: 'increment', n }),
+  delete: () => ({ real: 'delete' }),
+  arrayUnion: (...values) => ({ real: 'arrayUnion', values }),
+  arrayRemove: (...values) => ({ real: 'arrayRemove', values }),
+};

--- a/tests/modifyDataAdapter.test.mjs
+++ b/tests/modifyDataAdapter.test.mjs
@@ -15,6 +15,25 @@ const FieldValue = {
 const encodeIdKey = (id) =>
   `k_${Buffer.from(String(id), 'utf8').toString('base64url')}`;
 
+const buildCanonicalRowUpdate = ({ row, modify }) => {
+  const rowKey = encodeIdKey('1');
+  const result = modifyDataAdapter.buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: {
+      items: {
+        type: 'Collection',
+        order: ['1'],
+        valueById: { [rowKey]: { id: '1', ...row } },
+      },
+    },
+    modify,
+    FieldValue,
+    language: 'en_US',
+  });
+  return { result, rowKey };
+};
+
 test('buildUserDocUpdate uses FieldValue.increment on simple paths', () => {
   const { buildUserDocUpdate } = modifyDataAdapter;
   const userData = { count: 1 };
@@ -100,8 +119,8 @@ test('buildUserDocUpdate keeps numeric @getByKey values as map keys', () => {
   });
 });
 
-test('buildUserDocUpdate rewrites parent map for @getByKey keys containing dots', () => {
-  const { buildUserDocUpdate } = modifyDataAdapter;
+test('buildUserDocUpdate emits a structured field path for nested dotted keys', () => {
+  const { buildUserDocUpdate, FIELD_PATH_UPDATES } = modifyDataAdapter;
   const userData = {
     Points: {
       'Thu.03': { score: 1 },
@@ -122,16 +141,17 @@ test('buildUserDocUpdate rewrites parent map for @getByKey keys containing dots'
     language: 'en_US',
   });
 
-  assert.deepEqual(Object.keys(update), ['Points']);
-  assert.deepEqual(update.Points['Thu.03'].score, {
-    __op: 'increment',
-    n: 1,
-  });
-  assert.deepEqual(update.Points.Safe, { score: 9 });
+  assert.deepEqual(Object.keys(update), []);
+  assert.deepEqual(update[FIELD_PATH_UPDATES], [
+    {
+      segments: ['Points', 'Thu.03', 'score'],
+      value: { __op: 'increment', n: 1 },
+    },
+  ]);
 });
 
-test('buildUserDocUpdate rewrites whole document for root @getByKey keys containing dots', () => {
-  const { buildUserDocUpdate, REPLACE_DOCUMENT_UPDATE } = modifyDataAdapter;
+test('buildUserDocUpdate emits a structured field path for root dotted keys', () => {
+  const { buildUserDocUpdate, FIELD_PATH_UPDATES } = modifyDataAdapter;
   const userData = {
     'Thu.03': { score: 1 },
     Safe: { score: 9 },
@@ -151,19 +171,16 @@ test('buildUserDocUpdate rewrites whole document for root @getByKey keys contain
   });
 
   assert.deepEqual(Object.keys(update), []);
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(update, REPLACE_DOCUMENT_UPDATE),
-    true,
-  );
-  assert.deepEqual(update[REPLACE_DOCUMENT_UPDATE]['Thu.03'].score, {
-    __op: 'increment',
-    n: 1,
-  });
-  assert.deepEqual(update[REPLACE_DOCUMENT_UPDATE].Safe, { score: 9 });
+  assert.deepEqual(update[FIELD_PATH_UPDATES], [
+    {
+      segments: ['Thu.03', 'score'],
+      value: { __op: 'increment', n: 1 },
+    },
+  ]);
 });
 
 test('buildUserDocUpdate does not collide replacement sentinel with user field names', () => {
-  const { buildUserDocUpdate, REPLACE_DOCUMENT_UPDATE } = modifyDataAdapter;
+  const { buildUserDocUpdate } = modifyDataAdapter;
   const userData = {};
 
   const update = buildUserDocUpdate({
@@ -179,10 +196,6 @@ test('buildUserDocUpdate does not collide replacement sentinel with user field n
     language: 'en_US',
   });
 
-  assert.equal(
-    Object.prototype.hasOwnProperty.call(update, REPLACE_DOCUMENT_UPDATE),
-    false,
-  );
   assert.deepEqual(update, {
     __replaceDocument: { ok: true },
   });
@@ -224,8 +237,8 @@ test('buildUserDocUpdate scopes non-set @getByKey array updates to the keyed bra
   ]);
 });
 
-test('buildUserDocUpdate rewrites keyed parent for non-set @getByKey arrays when key has dots', () => {
-  const { buildUserDocUpdate } = modifyDataAdapter;
+test('buildUserDocUpdate emits a structured field path for dotted keyed array rewrites', () => {
+  const { buildUserDocUpdate, FIELD_PATH_UPDATES } = modifyDataAdapter;
   const userData = {
     Points: {
       'Thu.03': {
@@ -250,10 +263,45 @@ test('buildUserDocUpdate rewrites keyed parent for non-set @getByKey arrays when
     language: 'en_US',
   });
 
-  assert.deepEqual(Object.keys(update), ['Points']);
-  assert.deepEqual(update.Points['Thu.03'].items, [
-    { id: '1', tags: ['a'] },
-    { id: '2', tags: ['b', 'c'] },
+  assert.deepEqual(Object.keys(update), []);
+  assert.deepEqual(update[FIELD_PATH_UPDATES], [
+    {
+      segments: ['Points', 'Thu.03', 'items'],
+      value: [
+        { id: '1', tags: ['a'] },
+        { id: '2', tags: ['b', 'c'] },
+      ],
+    },
+  ]);
+});
+
+test('buildUserDocUpdate rewrites arrays beneath dotted keys before submitting', () => {
+  const { buildUserDocUpdate, FIELD_PATH_UPDATES } = modifyDataAdapter;
+  const userData = {
+    'Thu.03': {
+      items: [{ name: 'a' }, { name: 'b' }],
+    },
+  };
+
+  const update = buildUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData,
+    modify: {
+      property: '/@getByKey:Thu.03/items/@getByIndex:1/name',
+      func: 'set',
+      value: 'B',
+    },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  assert.deepEqual(Object.keys(update), []);
+  assert.deepEqual(update[FIELD_PATH_UPDATES], [
+    {
+      segments: ['Thu.03', 'items'],
+      value: [{ name: 'a' }, { name: 'B' }],
+    },
   ]);
 });
 
@@ -473,7 +521,7 @@ test('buildUserDocUpdate delbyvalue on Collection wrapper migrates to canonical 
   assert.equal(update.items.value, undefined);
 });
 
-test('buildUserDocUpdate add on canonical Collection wrapper preserves order/valueById', () => {
+test('buildUserDocUpdate add on canonical Collection uses atomic membership', () => {
   const { buildUserDocUpdate } = modifyDataAdapter;
   const userData = {
     items: {
@@ -503,14 +551,17 @@ test('buildUserDocUpdate add on canonical Collection wrapper preserves order/val
     'items.order',
     `items.valueById.${encodeIdKey('2')}`,
   ]);
-  assert.deepEqual(update['items.order'], ['1', '2']);
+  assert.deepEqual(update['items.order'], {
+    __op: 'arrayUnion',
+    values: ['2'],
+  });
   assert.deepEqual(update[`items.valueById.${encodeIdKey('2')}`], {
     id: '2',
     name: 'b',
   });
 });
 
-test('buildUserDocUpdate add on canonical Collection with existing id falls back to rewrite', () => {
+test('buildUserDocUpdate add on canonical Collection with existing id merges one row', () => {
   const { buildUserDocUpdate } = modifyDataAdapter;
   const userData = {
     items: {
@@ -537,22 +588,22 @@ test('buildUserDocUpdate add on canonical Collection with existing id falls back
     language: 'en_US',
   });
 
-  assert.deepEqual(Object.keys(update), ['items']);
-  assert.equal(update.items.type, 'Collection');
-  assert.deepEqual(update.items.schema, { path: { value: '/cards' } });
-  assert.deepEqual(update.items.order, ['1', '2']);
-  assert.deepEqual(update.items.valueById[encodeIdKey('1')], {
-    id: '1',
-    name: 'a',
+  assert.deepEqual(Object.keys(update).sort(), [
+    'items.order',
+    `items.valueById.${encodeIdKey('2')}`,
+  ]);
+  assert.deepEqual(update['items.order'], {
+    __op: 'arrayUnion',
+    values: ['2'],
   });
-  assert.deepEqual(update.items.valueById[encodeIdKey('2')], {
+  assert.deepEqual(update[`items.valueById.${encodeIdKey('2')}`], {
     id: '2',
     name: 'b',
     score: 2,
   });
 });
 
-test('buildUserDocUpdate delbyid on canonical Collection wrapper preserves order/valueById', () => {
+test('buildUserDocUpdate delbyid on canonical Collection uses atomic membership and row delete', () => {
   const { buildUserDocUpdate } = modifyDataAdapter;
   const userData = {
     items: {
@@ -579,15 +630,17 @@ test('buildUserDocUpdate delbyid on canonical Collection wrapper preserves order
     language: 'en_US',
   });
 
-  assert.deepEqual(Object.keys(update), ['items']);
-  assert.equal(update.items.type, 'Collection');
-  assert.deepEqual(update.items.schema, { path: { value: '/cards' } });
-  assert.deepEqual(update.items.order, ['1']);
-  assert.deepEqual(update.items.valueById[encodeIdKey('1')], {
-    id: '1',
-    name: 'a',
+  assert.deepEqual(Object.keys(update).sort(), [
+    'items.order',
+    `items.valueById.${encodeIdKey('2')}`,
+  ]);
+  assert.deepEqual(update['items.order'], {
+    __op: 'arrayRemove',
+    values: ['2'],
   });
-  assert.equal(update.items.valueById[encodeIdKey('2')], undefined);
+  assert.deepEqual(update[`items.valueById.${encodeIdKey('2')}`], {
+    __op: 'delete',
+  });
 });
 
 test('buildUserDocUpdate migrates legacy Collection @getById set to canonical storage', () => {
@@ -1418,4 +1471,762 @@ test('buildUserDocUpdate returns null when @getById base array is missing', () =
   });
 
   assert.equal(update, null);
+});
+
+test('buildClassifiedUserDocUpdate emits FIELD_PATH_UPDATES for dotted literal keys', () => {
+  const { buildClassifiedUserDocUpdate, FIELD_PATH_UPDATES } = modifyDataAdapter;
+  const userData = { profile: { 'a.b': 1, keep: true } };
+
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData,
+    modify: {
+      property: [
+        { func: 'getKey', value: 'profile' },
+        { func: 'getKey', value: 'a.b' },
+      ],
+      func: 'set',
+      value: 2,
+    },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  assert.equal(result.category, 'targeted-write');
+  assert.deepEqual(result.update[FIELD_PATH_UPDATES], [
+    { segments: ['profile', 'a.b'], value: 2 },
+  ]);
+  // No parent clone: the dotted key must not force a rewrite of `profile`.
+  assert.equal(Object.keys(result.update).length, 0);
+});
+
+test('buildClassifiedUserDocUpdate uses structured paths for every Firestore path metacharacter', () => {
+  const { buildClassifiedUserDocUpdate, FIELD_PATH_UPDATES } = modifyDataAdapter;
+
+  for (const key of ['a~b', 'a*b', 'a/b', 'a[b', 'a]b']) {
+    const result = buildClassifiedUserDocUpdate({
+      JSONPointer,
+      ModifyData,
+      userData: { profile: { [key]: 1 } },
+      modify: {
+        property: [
+          { func: 'getKey', value: 'profile' },
+          { func: 'getKey', value: key },
+        ],
+        func: 'set',
+        value: 2,
+      },
+      FieldValue,
+      language: 'en_US',
+    });
+
+    assert.equal(result.category, 'targeted-write');
+    assert.deepEqual(result.update[FIELD_PATH_UPDATES], [
+      { segments: ['profile', key], value: 2 },
+    ]);
+    assert.deepEqual(Object.keys(result.update), []);
+  }
+});
+
+test('buildClassifiedUserDocUpdate classifies transforms, targeted writes and rewrites', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+
+  const inc = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: { count: 1 },
+    modify: { property: '/count', func: 'inc', value: 1 },
+    FieldValue,
+    language: 'en_US',
+  });
+  assert.equal(inc.category, 'atomic-transform');
+
+  const set = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: { name: 'a' },
+    modify: { property: '/name', func: 'set', value: 'b' },
+    FieldValue,
+    language: 'en_US',
+  });
+  assert.equal(set.category, 'targeted-write');
+  assert.deepEqual(set.update, { name: 'b' });
+
+  const rewrite = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: { rows: [{ id: '1', v: 1 }, { id: '2', v: 2 }] },
+    modify: {
+      property: '/rows/@find:id|eq|2/v',
+      func: 'set',
+      value: 9,
+    },
+    FieldValue,
+    language: 'en_US',
+  });
+  assert.equal(rewrite.category, 'local-rewrite');
+});
+
+test('canonical Collection selector transforms target valueById atomically', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const rowKey = encodeIdKey('1');
+  const userData = {
+    items: {
+      type: 'Collection',
+      order: ['1'],
+      valueById: {
+        [rowKey]: { id: '1', count: 0, tags: ['a'], obsolete: true },
+      },
+    },
+  };
+  const cases = [
+    {
+      modify: {
+        property: '/items/@getById:1/count',
+        func: 'inc',
+        value: 2,
+      },
+      field: 'count',
+      value: { __op: 'increment', n: 2 },
+    },
+    {
+      modify: {
+        property: '/items/@find:id|eq|1/obsolete',
+        func: 'del',
+      },
+      field: 'obsolete',
+      value: { __op: 'delete' },
+    },
+  ];
+
+  for (const entry of cases) {
+    const result = buildClassifiedUserDocUpdate({
+      JSONPointer,
+      ModifyData,
+      userData,
+      modify: entry.modify,
+      FieldValue,
+      language: 'en_US',
+    });
+
+    assert.equal(result.category, 'atomic-transform', entry.modify.property);
+    assert.deepEqual(result.update, {
+      [`items.valueById.${rowKey}.${entry.field}`]: entry.value,
+    });
+  }
+});
+
+test('add below a canonical Collection selector keeps ID-upsert semantics via local rewrite', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const rowKey = encodeIdKey('1');
+  const userData = {
+    items: {
+      type: 'Collection',
+      order: ['1'],
+      valueById: {
+        [rowKey]: { id: '1', children: [{ id: 'child', name: 'old' }] },
+      },
+    },
+  };
+
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData,
+    modify: {
+      property: '/items/@getById:1/children',
+      func: 'add',
+      value: { id: 'child', extra: 1 },
+    },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  // arrayUnion would append a second { id: 'child' } row; ModifyData's add
+  // merges into the existing same-ID row, so this must stay a local rewrite.
+  assert.equal(result.category, 'local-rewrite');
+  assert.deepEqual(result.update.items.valueById[rowKey].children, [
+    { id: 'child', name: 'old', extra: 1 },
+  ]);
+});
+
+test('inc below a canonical selector falls back to ModifyData when the value is a wrapper', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const rowKey = encodeIdKey('1');
+
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: {
+      items: {
+        type: 'Collection',
+        order: ['1'],
+        valueById: {
+          [rowKey]: { id: '1', score: { type: 'Number', value: 5 } },
+        },
+      },
+    },
+    modify: { property: '/items/@getById:1/score', func: 'inc', value: 2 },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  // A Firestore increment on the stored map would clobber it with the
+  // operand (2); ModifyData must produce the incremented result instead.
+  assert.equal(result.category, 'local-rewrite');
+  assert.equal(result.update.items.valueById[rowKey].score, 7);
+});
+
+test('inc below a canonical selector rewrites non-finite stored numbers', () => {
+  for (const score of [NaN, Infinity]) {
+    const { result, rowKey } = buildCanonicalRowUpdate({
+      row: { score },
+      modify: { property: '/items/@getById:1/score', func: 'inc', value: 2 },
+    });
+
+    assert.equal(result.category, 'local-rewrite');
+    assert.equal(result.update.items.valueById[rowKey].score, 2);
+  }
+});
+
+test('inc below a canonical selector preserves parseFloat operand semantics', () => {
+  const { result, rowKey } = buildCanonicalRowUpdate({
+    row: { score: 1 },
+    modify: { property: '/items/@getById:1/score', func: 'inc', value: '2px' },
+  });
+
+  assert.equal(result.category, 'local-rewrite');
+  assert.equal(result.update.items.valueById[rowKey].score, 3);
+});
+
+test('del of a whole canonical row updates membership, not just valueById', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const rowKey = encodeIdKey('1');
+
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: {
+      items: {
+        type: 'Collection',
+        order: ['1', '2'],
+        valueById: {
+          [rowKey]: { id: '1', v: 1 },
+          [encodeIdKey('2')]: { id: '2', v: 2 },
+        },
+      },
+    },
+    modify: { property: '/items/@getById:1', func: 'del' },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  // Deleting only the valueById entry would leave a dangling '1' in order.
+  assert.equal(result.category, 'atomic-transform');
+  assert.deepEqual(result.update, {
+    'items.order': { __op: 'arrayRemove', values: ['1'] },
+    [`items.valueById.${rowKey}`]: { __op: 'delete' },
+  });
+});
+
+test('del below a canonical selector preserves typed field wrappers', () => {
+  const { result, rowKey } = buildCanonicalRowUpdate({
+    row: { title: { type: 'Text', value: 'hello' } },
+    modify: { property: '/items/@getById:1/title', func: 'del' },
+  });
+
+  assert.equal(result.category, 'local-rewrite');
+  assert.deepEqual(result.update.items.valueById[rowKey].title, {
+    type: 'Text',
+    value: null,
+  });
+});
+
+test('delbyid below a canonical selector ignores non-array targets', () => {
+  const { result } = buildCanonicalRowUpdate({
+    row: { map: { entry: { id: 'x' } } },
+    modify: { property: '/items/@getById:1/map', func: 'delbyid', value: 'x' },
+  });
+
+  assert.equal(result, null);
+});
+
+test('delbyid below a canonical selector rewrites loose ID matches', () => {
+  const { result, rowKey } = buildCanonicalRowUpdate({
+    row: { rows: [{ id: 2 }, { id: '2' }, { id: 'keep' }] },
+    modify: { property: '/items/@getById:1/rows', func: 'delbyid', value: '2' },
+  });
+
+  assert.equal(result.category, 'local-rewrite');
+  assert.deepEqual(result.update.items.valueById[rowKey].rows, [
+    { id: 'keep' },
+  ]);
+});
+
+test('delbyvalue below a canonical selector requires an actual array target', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const rowKey = encodeIdKey('1');
+
+  // Firestore arrayRemove would replace the stored map with []; ModifyData
+  // treats delbyvalue on a non-array as a no-op, so the plan must be null.
+  const onMap = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: {
+      items: {
+        type: 'Collection',
+        order: ['1'],
+        valueById: { [rowKey]: { id: '1', map: { keep: true } } },
+      },
+    },
+    modify: { property: '/items/@getById:1/map', func: 'delbyvalue', value: 'x' },
+    FieldValue,
+    language: 'en_US',
+  });
+  assert.equal(onMap, null);
+
+  // A real array keeps the atomic fast path.
+  const onArray = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: {
+      items: {
+        type: 'Collection',
+        order: ['1'],
+        valueById: { [rowKey]: { id: '1', tags: ['a', 'b'] } },
+      },
+    },
+    modify: { property: '/items/@getById:1/tags', func: 'delbyvalue', value: 'a' },
+    FieldValue,
+    language: 'en_US',
+  });
+  assert.equal(onArray.category, 'atomic-transform');
+  assert.deepEqual(onArray.update, {
+    [`items.valueById.${rowKey}.tags`]: { __op: 'arrayRemove', values: ['a'] },
+  });
+});
+
+test('delbyvalue below a canonical selector rewrites wrapped array values', () => {
+  const { result, rowKey } = buildCanonicalRowUpdate({
+    row: { tags: [{ type: 'Text', value: 'x' }] },
+    modify: {
+      property: '/items/@getById:1/tags',
+      func: 'delbyvalue',
+      value: 'x',
+    },
+  });
+
+  assert.equal(result.category, 'local-rewrite');
+  assert.deepEqual(result.update.items.valueById[rowKey].tags, []);
+});
+
+test('membership transforms target the exact stored order value for unnormalized IDs', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const rowKey = encodeIdKey('1');
+
+  // Upsert over a numerically-stored ID: arrayUnion('1') would produce
+  // [1, '1']; the transform must reuse the stored numeric value.
+  const upsert = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: {
+      items: { type: 'Collection', order: [1], valueById: { [rowKey]: { id: '1', v: 1 } } },
+    },
+    modify: { property: '/items', func: 'add', value: { id: '1', v: 5 } },
+    FieldValue,
+    language: 'en_US',
+  });
+  assert.deepEqual(upsert.update['items.order'], {
+    __op: 'arrayUnion',
+    values: [1],
+  });
+
+  // Same for removal: arrayRemove('2') would leave the numeric 2 behind.
+  const removal = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: {
+      items: {
+        type: 'Collection',
+        order: [1, 2],
+        valueById: {
+          [rowKey]: { id: '1', v: 1 },
+          [encodeIdKey('2')]: { id: '2', v: 2 },
+        },
+      },
+    },
+    modify: { property: '/items', func: 'delbyid', value: '2' },
+    FieldValue,
+    language: 'en_US',
+  });
+  assert.deepEqual(removal.update['items.order'], {
+    __op: 'arrayRemove',
+    values: [2],
+  });
+});
+
+test('canonical Collection add uses arrayUnion membership plus one row write', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const collection = {
+    type: 'Collection',
+    order: ['1'],
+    valueById: { [encodeIdKey('1')]: { id: '1', v: 1 } },
+  };
+
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: { items: collection },
+    modify: {
+      property: '/items',
+      func: 'add',
+      value: { id: '2', v: 2 },
+    },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  assert.equal(result.category, 'atomic-transform');
+  assert.deepEqual(result.update, {
+    'items.order': { __op: 'arrayUnion', values: ['2'] },
+    [`items.valueById.${encodeIdKey('2')}`]: { id: '2', v: 2 },
+  });
+});
+
+test('canonical Collection add of an existing ID stays a membership no-op plus row merge', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const collection = {
+    type: 'Collection',
+    order: ['1'],
+    valueById: { [encodeIdKey('1')]: { id: '1', v: 1 } },
+  };
+
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: { items: collection },
+    modify: {
+      property: '/items',
+      func: 'add',
+      value: { id: '1', v: 5 },
+    },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  assert.equal(result.category, 'atomic-transform');
+  assert.equal(
+    result.update['items.order'].__op,
+    'arrayUnion',
+    'membership must stay an arrayUnion no-op, never a literal order rewrite',
+  );
+  assert.deepEqual(
+    result.update[`items.valueById.${encodeIdKey('1')}`],
+    { id: '1', v: 5 },
+  );
+});
+
+test('canonical Collection add of an identical existing row stays atomic', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const row = { id: '1', v: 1 };
+  const collection = {
+    type: 'Collection',
+    order: ['1'],
+    valueById: { [encodeIdKey('1')]: row },
+  };
+
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: { items: collection },
+    modify: { property: '/items', func: 'add', value: row },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  assert.equal(result.category, 'atomic-transform');
+  assert.deepEqual(result.update, {
+    'items.order': { __op: 'arrayUnion', values: ['1'] },
+    [`items.valueById.${encodeIdKey('1')}`]: row,
+  });
+});
+
+test('canonical Collection delbyid uses arrayRemove membership plus row delete', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const collection = {
+    type: 'Collection',
+    order: ['1', '2'],
+    valueById: {
+      [encodeIdKey('1')]: { id: '1', v: 1 },
+      [encodeIdKey('2')]: { id: '2', v: 2 },
+    },
+  };
+
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: { items: collection },
+    modify: { property: '/items', func: 'delbyid', value: '2' },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  assert.equal(result.category, 'atomic-transform');
+  assert.deepEqual(result.update, {
+    'items.order': { __op: 'arrayRemove', values: ['2'] },
+    [`items.valueById.${encodeIdKey('2')}`]: { __op: 'delete' },
+  });
+});
+
+test('canonical delete paths remove rows stored under legacy raw keys', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const row = { id: 'foo', v: 1 };
+  const modifications = [
+    { property: '/items', func: 'delbyid', value: 'foo' },
+    { property: '/items', func: 'delbyvalue', value: row },
+    { property: '/items/@getById:foo', func: 'del' },
+  ];
+
+  for (const modify of modifications) {
+    const result = buildClassifiedUserDocUpdate({
+      JSONPointer,
+      ModifyData,
+      userData: {
+        items: {
+          type: 'Collection',
+          order: ['foo'],
+          valueById: { foo: row },
+        },
+      },
+      modify,
+      FieldValue,
+      language: 'en_US',
+    });
+
+    assert.equal(result.category, 'atomic-transform', modify.func);
+    assert.deepEqual(result.update, {
+      'items.order': { __op: 'arrayRemove', values: ['foo'] },
+      'items.valueById.foo': { __op: 'delete' },
+    });
+  }
+});
+
+test('canonical Collection delbyid removes equivalent memberships when the row is absent locally', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: {
+      items: { type: 'Collection', order: [], valueById: {} },
+    },
+    modify: { property: '/items', func: 'delbyid', value: '1' },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  assert.equal(result.category, 'atomic-transform');
+  assert.deepEqual(result.update, {
+    'items.order': { __op: 'arrayRemove', values: ['1', 1] },
+    [`items.valueById.${encodeIdKey('1')}`]: { __op: 'delete' },
+  });
+});
+
+test('inc and dec of a missing canonical row field stay atomic', () => {
+  for (const [func, operand] of [
+    ['inc', 2],
+    ['dec', -2],
+  ]) {
+    const { result, rowKey } = buildCanonicalRowUpdate({
+      row: { untouched: true },
+      modify: {
+        property: '/items/@getById:1/score',
+        func,
+        value: 2,
+      },
+    });
+
+    assert.equal(result.category, 'atomic-transform', func);
+    assert.deepEqual(result.update, {
+      [`items.valueById.${rowKey}.score`]: {
+        __op: 'increment',
+        n: operand,
+      },
+    });
+  }
+});
+
+test('plain-array delbyid keeps exact-row arrayRemove', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: { rows: [{ id: '1', v: 1 }] },
+    modify: { property: '/rows', func: 'delbyid', value: '1' },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  assert.equal(result.category, 'atomic-transform');
+  assert.deepEqual(result.update, {
+    rows: { __op: 'arrayRemove', values: [{ id: '1', v: 1 }] },
+  });
+});
+
+test('parsePointerObjects returns [] for an unparseable property', () => {
+  const { parsePointerObjects } = modifyDataAdapter;
+  assert.deepEqual(
+    parsePointerObjects({ JSONPointer, property: 42 }),
+    [],
+  );
+});
+
+test('buildClassifiedUserDocUpdate classifies @getById array set as a local rewrite', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: { rows: [{ id: '1', v: 1 }, { id: '2', v: 2 }] },
+    modify: {
+      property: '/rows/@getById:2/v',
+      func: 'set',
+      value: 9,
+    },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  assert.equal(result.category, 'local-rewrite');
+  assert.deepEqual(result.update, {
+    rows: [{ id: '1', v: 1 }, { id: '2', v: 9 }],
+  });
+});
+
+test('buildClassifiedUserDocUpdate classifies @getByIndex array set as a local rewrite', () => {
+  const { buildClassifiedUserDocUpdate } = modifyDataAdapter;
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: { rows: [{ v: 1 }, { v: 2 }] },
+    modify: {
+      property: '/rows/@getByIndex:1/v',
+      func: 'set',
+      value: 9,
+    },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  assert.equal(result.category, 'local-rewrite');
+  assert.deepEqual(result.update, {
+    rows: [{ v: 1 }, { v: 9 }],
+  });
+});
+
+test('canonical Collection targeted set beneath a dotted literal key uses FIELD_PATH_UPDATES', () => {
+  const { buildClassifiedUserDocUpdate, FIELD_PATH_UPDATES } = modifyDataAdapter;
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: {
+      'a.b': {
+        type: 'Collection',
+        order: ['1'],
+        valueById: { [encodeIdKey('1')]: { id: '1', v: 1 } },
+      },
+    },
+    modify: {
+      property: [
+        { func: 'getKey', value: 'a.b' },
+        { func: 'getById', value: '1' },
+        { func: 'getKey', value: 'v' },
+      ],
+      func: 'set',
+      value: 9,
+    },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  assert.equal(result.category, 'targeted-write');
+  assert.deepEqual(Object.keys(result.update), []);
+  assert.deepEqual(result.update[FIELD_PATH_UPDATES], [
+    {
+      segments: ['a.b', 'valueById', encodeIdKey('1'), 'v'],
+      value: 9,
+    },
+  ]);
+});
+
+test('canonical Collection add beneath a dotted literal key uses FIELD_PATH_UPDATES', () => {
+  const { buildClassifiedUserDocUpdate, FIELD_PATH_UPDATES } = modifyDataAdapter;
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: {
+      'a.b': {
+        type: 'Collection',
+        order: ['1'],
+        valueById: { [encodeIdKey('1')]: { id: '1', v: 1 } },
+      },
+    },
+    modify: {
+      property: [{ func: 'getKey', value: 'a.b' }],
+      func: 'add',
+      value: { id: '2', v: 2 },
+    },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  assert.equal(result.category, 'atomic-transform');
+  assert.deepEqual(Object.keys(result.update), []);
+  assert.deepEqual(result.update[FIELD_PATH_UPDATES], [
+    {
+      segments: ['a.b', 'order'],
+      value: { __op: 'arrayUnion', values: ['2'] },
+    },
+    {
+      segments: ['a.b', 'valueById', encodeIdKey('2')],
+      value: { id: '2', v: 2 },
+    },
+  ]);
+});
+
+test('canonical Collection delete beneath a dotted literal key uses FIELD_PATH_UPDATES', () => {
+  const { buildClassifiedUserDocUpdate, FIELD_PATH_UPDATES } = modifyDataAdapter;
+  const result = buildClassifiedUserDocUpdate({
+    JSONPointer,
+    ModifyData,
+    userData: {
+      'a.b': {
+        type: 'Collection',
+        order: ['1', '2'],
+        valueById: {
+          [encodeIdKey('1')]: { id: '1', v: 1 },
+          [encodeIdKey('2')]: { id: '2', v: 2 },
+        },
+      },
+    },
+    modify: {
+      property: [{ func: 'getKey', value: 'a.b' }],
+      func: 'delbyid',
+      value: '2',
+    },
+    FieldValue,
+    language: 'en_US',
+  });
+
+  assert.equal(result.category, 'atomic-transform');
+  assert.deepEqual(Object.keys(result.update), []);
+  assert.deepEqual(result.update[FIELD_PATH_UPDATES], [
+    {
+      segments: ['a.b', 'order'],
+      value: { __op: 'arrayRemove', values: ['2'] },
+    },
+    {
+      segments: ['a.b', 'valueById', encodeIdKey('2')],
+      value: { __op: 'delete' },
+    },
+  ]);
 });

--- a/tests/mutationPlanner.test.mjs
+++ b/tests/mutationPlanner.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { JSONPointer, ModifyData } from '@beingenious/jsonpointer';
+
+import { planChange } from '../src/hooks/useFirebaseWithBridge/mutationPlanner.mjs';
+
+const plan = (modify, userDoc) =>
+  planChange({ JSONPointer, ModifyData, modify, userDoc, language: 'en_US' });
+
+test('malformed action is invalid with a stable reason', () => {
+  assert.deepEqual(plan(null, {}), {
+    kind: 'invalid',
+    reason: 'change/malformed-action',
+  });
+  assert.deepEqual(plan({ func: 'set', value: 1 }, {}), {
+    kind: 'invalid',
+    reason: 'change/malformed-action',
+  });
+  assert.deepEqual(plan({ property: '/x', func: 123, value: 1 }, {}), {
+    kind: 'invalid',
+    reason: 'change/malformed-action',
+  });
+});
+
+test('unparseable pointer is invalid, unmatched selector is a noop', () => {
+  assert.equal(plan({ property: 42, func: 'set', value: 1 }, {}).kind, 'invalid');
+  assert.equal(
+    plan(
+      { property: '/rows/@find:id|eq|missing/v', func: 'set', value: 1 },
+      { rows: [{ id: '1', v: 1 }] },
+    ).kind,
+    'noop',
+  );
+});
+
+test('set on a stable field returns a targeted write and the expected document', () => {
+  const result = plan({ property: '/name', func: 'set', value: 'b' }, { name: 'a' });
+  assert.equal(result.kind, 'targeted-write');
+  assert.deepEqual(result.update, { name: 'b' });
+  assert.deepEqual(result.expectedDoc, { name: 'b' });
+});
+
+test('set preserves a sentinel-looking literal in the write and expected document', () => {
+  const literal = { __pandaFsSentinel: 'delete', keep: 1 };
+  const result = plan(
+    { property: '/payload', func: 'set', value: literal },
+    { payload: { old: true } },
+  );
+
+  assert.equal(result.kind, 'targeted-write');
+  assert.deepEqual(result.update, { payload: literal });
+  assert.deepEqual(result.expectedDoc, { payload: literal });
+});
+
+test('planner treats cyclic non-plain Firestore values as opaque', () => {
+  class FirestoreReferenceLike {
+    constructor() {
+      this.delegate = this;
+    }
+  }
+
+  const reference = new FirestoreReferenceLike();
+  const result = plan(
+    { property: '/name', func: 'set', value: 'b' },
+    { name: 'a', reference },
+  );
+
+  assert.equal(result.kind, 'targeted-write');
+  assert.equal(
+    result.expectedDoc.reference instanceof FirestoreReferenceLike,
+    true,
+  );
+  assert.equal(
+    result.expectedDoc.reference.delegate,
+    result.expectedDoc.reference,
+  );
+});
+
+test('inc returns an atomic transform whose expected document is already incremented', () => {
+  const result = plan(
+    { property: '/count', func: 'inc', value: { type: 'Integer', value: '2' } },
+    { count: 1 },
+  );
+  assert.equal(result.kind, 'atomic-transform');
+  assert.deepEqual(result.expectedDoc, { count: 3 });
+});
+
+test('same-value set preserves the server write intent', () => {
+  const result = plan(
+    { property: '/name', func: 'set', value: 'a' },
+    { name: 'a' },
+  );
+  assert.equal(result.kind, 'targeted-write');
+  assert.deepEqual(result.update, { name: 'a' });
+  assert.deepEqual(result.expectedDoc, { name: 'a' });
+});
+
+test('same-value set through a matched selector preserves the rewrite intent', () => {
+  const userDoc = { rows: [{ id: '1', v: 1 }] };
+  const result = plan(
+    { property: '/rows/@find:id|eq|1/v', func: 'set', value: 1 },
+    userDoc,
+  );
+
+  assert.equal(result.kind, 'local-rewrite');
+  assert.deepEqual(result.update, { rows: [{ id: '1', v: 1 }] });
+  assert.deepEqual(result.expectedDoc, userDoc);
+});
+
+test('add of a cached array value preserves the server transform intent', () => {
+  const result = plan(
+    { property: '/tags', func: 'add', value: 'a' },
+    { tags: ['a'] },
+  );
+  assert.equal(result.kind, 'atomic-transform');
+  assert.deepEqual(result.expectedDoc, { tags: ['a'] });
+});
+
+test('delete of a locally missing field preserves the server transform intent', () => {
+  const result = plan({ property: '/obsolete', func: 'del' }, {});
+  assert.equal(result.kind, 'atomic-transform');
+  assert.deepEqual(result.expectedDoc, {});
+});
+
+test('selector rewrite freezes the target from the local state', () => {
+  const userDoc = { rows: [{ id: '1', v: 1 }, { id: '2', v: 2 }] };
+  const result = plan(
+    { property: '/rows/@find:id|eq|2/v', func: 'set', value: 9 },
+    userDoc,
+  );
+  assert.equal(result.kind, 'local-rewrite');
+  assert.deepEqual(result.expectedDoc.rows, [
+    { id: '1', v: 1 },
+    { id: '2', v: 9 },
+  ]);
+  // Input document is never mutated (planner purity).
+  assert.deepEqual(userDoc.rows[1], { id: '2', v: 2 });
+});

--- a/tests/mutationSentinels.test.mjs
+++ b/tests/mutationSentinels.test.mjs
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  applyUpdateToDoc,
+  isSentinel,
+  plannerFieldValue,
+  toFirestoreValue,
+} from '../src/hooks/useFirebaseWithBridge/mutationSentinels.mjs';
+import { FIELD_PATH_UPDATES } from '../src/hooks/useFirebaseWithBridge/modifyDataAdapter.mjs';
+
+test('increment adds to any number and replaces non-numbers, like Firestore', () => {
+  assert.deepEqual(
+    applyUpdateToDoc({
+      doc: { n: 5 },
+      update: { n: plannerFieldValue.increment(2) },
+    }),
+    { n: 7 },
+  );
+  // IEEE arithmetic on non-finite numbers matches Firestore's local result.
+  assert.ok(
+    Number.isNaN(
+      applyUpdateToDoc({
+        doc: { n: NaN },
+        update: { n: plannerFieldValue.increment(2) },
+      }).n,
+    ),
+  );
+  assert.deepEqual(
+    applyUpdateToDoc({
+      doc: { n: Infinity },
+      update: { n: plannerFieldValue.increment(2) },
+    }),
+    { n: Infinity },
+  );
+  assert.deepEqual(
+    applyUpdateToDoc({
+      doc: { n: 'x' },
+      update: { n: plannerFieldValue.increment(2) },
+    }),
+    { n: 2 },
+  );
+  assert.deepEqual(
+    applyUpdateToDoc({
+      doc: {},
+      update: { n: plannerFieldValue.increment(2) },
+    }),
+    { n: 2 },
+  );
+});
+
+test('a nested delete through a missing or non-map parent leaves the document untouched', () => {
+  // Firestore ignores `a.b: delete()` when `a` is a scalar or missing; the
+  // simulation must not materialize `a` as an empty map.
+  assert.deepEqual(
+    applyUpdateToDoc({
+      doc: { a: 5 },
+      update: { 'a.b': plannerFieldValue.delete() },
+    }),
+    { a: 5 },
+  );
+  assert.deepEqual(
+    applyUpdateToDoc({
+      doc: {},
+      update: { 'a.b': plannerFieldValue.delete() },
+    }),
+    {},
+  );
+});
+
+test('delete removes the field', () => {
+  assert.deepEqual(
+    applyUpdateToDoc({
+      doc: { a: 1, b: 2 },
+      update: { a: plannerFieldValue.delete() },
+    }),
+    { b: 2 },
+  );
+  assert.deepEqual(
+    applyUpdateToDoc({
+      doc: { profile: { 'a.b': 1, keep: true } },
+      update: {
+        [FIELD_PATH_UPDATES]: [
+          {
+            segments: ['profile', 'a.b'],
+            value: plannerFieldValue.delete(),
+          },
+        ],
+      },
+    }),
+    { profile: { keep: true } },
+  );
+});
+
+test('arrayUnion deduplicates by deep equality, arrayRemove removes every match', () => {
+  assert.deepEqual(
+    applyUpdateToDoc({
+      doc: { arr: [{ v: 1 }] },
+      update: { arr: plannerFieldValue.arrayUnion({ v: 1 }, { v: 2 }) },
+    }),
+    { arr: [{ v: 1 }, { v: 2 }] },
+  );
+  assert.deepEqual(
+    applyUpdateToDoc({
+      doc: { arr: [{ v: 1 }, { v: 2 }, { v: 1 }] },
+      update: { arr: plannerFieldValue.arrayRemove({ v: 1 }) },
+    }),
+    { arr: [{ v: 2 }] },
+  );
+  // Non-array current value: union/remove replace it, like Firestore does.
+  assert.deepEqual(
+    applyUpdateToDoc({
+      doc: { arr: 3 },
+      update: { arr: plannerFieldValue.arrayUnion(1) },
+    }),
+    { arr: [1] },
+  );
+  assert.deepEqual(
+    applyUpdateToDoc({
+      doc: { arr: 3 },
+      update: { arr: plannerFieldValue.arrayRemove(1) },
+    }),
+    { arr: [] },
+  );
+});
+
+test('string paths walk literal keys and never create arrays', () => {
+  assert.deepEqual(applyUpdateToDoc({ doc: {}, update: { 'a.b': 1 } }), {
+    a: { b: 1 },
+  });
+});
+
+test('new documents and nested maps have ordinary object prototypes', () => {
+  const next = applyUpdateToDoc({ doc: null, update: { 'a.b': 1 } });
+
+  assert.equal(Object.getPrototypeOf(next), Object.prototype);
+  assert.equal(Object.getPrototypeOf(next.a), Object.prototype);
+  assert.deepEqual(next, { a: { b: 1 } });
+});
+
+test('prototype-chain paths cannot pollute global objects', () => {
+  delete Object.prototype.polluted;
+
+  try {
+    const next = applyUpdateToDoc({
+      doc: {},
+      update: { '__proto__.polluted': true },
+    });
+
+    assert.equal(Object.prototype.polluted, undefined);
+    assert.deepEqual(next, {});
+  } finally {
+    delete Object.prototype.polluted;
+  }
+});
+
+test('FIELD_PATH_UPDATES segments treat dots as literal key characters', () => {
+  const update = {
+    [FIELD_PATH_UPDATES]: [{ segments: ['profile', 'a.b'], value: 2 }],
+  };
+  assert.deepEqual(
+    applyUpdateToDoc({ doc: { profile: { 'a.b': 1, keep: true } }, update }),
+    { profile: { 'a.b': 2, keep: true } },
+  );
+});
+
+test('applyUpdateToDoc never mutates its inputs', () => {
+  const doc = { a: { b: 1 }, arr: [1] };
+  applyUpdateToDoc({
+    doc,
+    update: { 'a.b': 2, arr: plannerFieldValue.arrayUnion(2) },
+  });
+  assert.deepEqual(doc, { a: { b: 1 }, arr: [1] });
+});
+
+test('a sentinel-looking literal is not a planner sentinel', () => {
+  assert.equal(isSentinel({ __pandaFsSentinel: 'delete', keep: 1 }), false);
+});
+
+test('applyUpdateToDoc writes a sentinel-looking literal as data', () => {
+  const literal = { __pandaFsSentinel: 'delete', keep: 1 };
+
+  assert.deepEqual(
+    applyUpdateToDoc({
+      doc: { payload: { old: true } },
+      update: { payload: literal },
+    }),
+    { payload: literal },
+  );
+});
+
+test('toFirestoreValue passes a sentinel-looking literal through unchanged', () => {
+  const literal = { __pandaFsSentinel: 'delete', keep: 1 };
+  const FieldValue = { delete: () => ({ real: 'delete' }) };
+
+  assert.strictEqual(toFirestoreValue(literal, FieldValue), literal);
+});
+
+test('toFirestoreValue maps sentinels to the injected FieldValue', () => {
+  const calls = [];
+  const FieldValue = {
+    increment: (n) => calls.push(['increment', n]) && 'INC',
+    delete: () => calls.push(['delete']) && 'DEL',
+    arrayUnion: (...v) => calls.push(['arrayUnion', v]) && 'AU',
+    arrayRemove: (...v) => calls.push(['arrayRemove', v]) && 'AR',
+  };
+
+  assert.equal(
+    toFirestoreValue(plannerFieldValue.increment(3), FieldValue),
+    'INC',
+  );
+  assert.equal(toFirestoreValue(plannerFieldValue.delete(), FieldValue), 'DEL');
+  assert.equal(
+    toFirestoreValue(plannerFieldValue.arrayUnion(1, 2), FieldValue),
+    'AU',
+  );
+  assert.equal(
+    toFirestoreValue(plannerFieldValue.arrayRemove(1), FieldValue),
+    'AR',
+  );
+  assert.equal(toFirestoreValue({ plain: true }, FieldValue).plain, true);
+  assert.equal(isSentinel(plannerFieldValue.delete()), true);
+  assert.equal(isSentinel({ plain: true }), false);
+  assert.deepEqual(calls, [
+    ['increment', 3],
+    ['delete'],
+    ['arrayUnion', [1, 2]],
+    ['arrayRemove', [1]],
+  ]);
+});

--- a/tests/userDocSequencer.test.mjs
+++ b/tests/userDocSequencer.test.mjs
@@ -1,0 +1,566 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createUserDocSequencer } from '../src/hooks/useFirebaseWithBridge/userDocSequencer.mjs';
+
+// Deterministic fakes. `planAction` delegates to a per-test queue of plans or
+// a function; `submitWrite` records calls and returns controllable promises.
+const createHarness = ({ planAction }) => {
+  const writes = [];
+  const errors = [];
+  const pending = [];
+  const sequencer = createUserDocSequencer({
+    planAction,
+    submitWrite: (write) => {
+      writes.push(write);
+      return new Promise((resolve, reject) => {
+        pending.push({ resolve, reject });
+      });
+    },
+    readCache: () => Promise.reject(new Error('not used in this task')),
+    onChangeError: (code, message) => errors.push({ code, message }),
+  });
+  return { sequencer, writes, errors, pending };
+};
+
+const settle = () => new Promise((resolve) => setImmediate(resolve));
+
+test('actions are held until a snapshot establishes existence', async () => {
+  const { sequencer, writes } = createHarness({
+    planAction: ({ userDoc }) => ({
+      kind: 'targeted-write',
+      update: { a: 1 },
+      expectedDoc: { ...userDoc, a: 1 },
+    }),
+  });
+
+  sequencer.setUid('u1');
+  sequencer.enqueue({ uid: 'u1', modify: { property: '/a', func: 'set', value: 1 } });
+  assert.equal(writes.length, 0);
+  assert.equal(sequencer.inspect().queueLength, 1);
+
+  sequencer.handleSnapshot({ uid: 'u1', exists: true, fromCache: true, getData: () => ({}) });
+  assert.equal(writes.length, 1);
+  assert.equal(sequencer.inspect().queueLength, 0);
+});
+
+test('a cache miss does not establish missing; a non-cache snapshot does', () => {
+  const { sequencer, writes } = createHarness({
+    planAction: () => ({ kind: 'targeted-write', update: { a: 1 }, expectedDoc: { a: 1 } }),
+  });
+
+  sequencer.setUid('u1');
+  sequencer.enqueue({ uid: 'u1', modify: {} });
+
+  sequencer.handleSnapshot({ uid: 'u1', exists: false, fromCache: true, getData: () => undefined });
+  assert.equal(sequencer.inspect().existence, 'unknown');
+  assert.equal(writes.length, 0);
+
+  sequencer.handleSnapshot({ uid: 'u1', exists: false, fromCache: false, getData: () => undefined });
+  assert.equal(sequencer.inspect().existence, 'missing');
+  // Known missing: queued action resolved as a documented silent no-op.
+  assert.equal(writes.length, 0);
+  assert.equal(sequencer.inspect().queueLength, 0);
+});
+
+test('known-missing recovers when a snapshot observes creation by an owning flow', () => {
+  const { sequencer, writes } = createHarness({
+    planAction: ({ userDoc }) => ({
+      kind: 'targeted-write',
+      update: { a: 1 },
+      expectedDoc: { ...userDoc, a: 1 },
+    }),
+  });
+
+  sequencer.setUid('u1');
+  sequencer.handleSnapshot({ uid: 'u1', exists: false, fromCache: false, getData: () => undefined });
+  sequencer.enqueue({ uid: 'u1', modify: {} });
+  assert.equal(writes.length, 0);
+
+  sequencer.handleSnapshot({ uid: 'u1', exists: true, fromCache: false, getData: () => ({ seeded: true }) });
+  sequencer.enqueue({ uid: 'u1', modify: {} });
+  assert.equal(writes.length, 1);
+});
+
+test('non-transform actions chain on expectedDoc while writes stay pending', async () => {
+  const seen = [];
+  const { sequencer, writes } = createHarness({
+    planAction: ({ modify, userDoc }) => {
+      seen.push(userDoc);
+      if (modify.func === 'add') {
+        return {
+          kind: 'targeted-write',
+          update: {},
+          expectedDoc: { rows: [{ id: '1', counter: 0 }] },
+        };
+      }
+      return {
+        kind: 'targeted-write',
+        update: {},
+        expectedDoc: { rows: [{ id: '1', counter: 1 }] },
+      };
+    },
+  });
+
+  sequencer.setUid('u1');
+  sequencer.handleSnapshot({ uid: 'u1', exists: true, fromCache: false, getData: () => ({ rows: [] }) });
+  sequencer.enqueue({ uid: 'u1', modify: { func: 'add' } });
+  sequencer.enqueue({ uid: 'u1', modify: { func: 'inc' } });
+
+  // Neither write promise has settled, yet the second plan saw the first's effect.
+  assert.equal(writes.length, 2);
+  assert.deepEqual(seen[0], { rows: [] });
+  assert.deepEqual(seen[1], { rows: [{ id: '1', counter: 0 }] });
+});
+
+test('noop plans skip the write; invalid plans emit onChangeError and continue', () => {
+  const plans = [
+    { kind: 'noop' },
+    { kind: 'invalid', reason: 'change/invalid-pointer' },
+    { kind: 'targeted-write', update: { a: 1 }, expectedDoc: { a: 1 } },
+  ];
+  const { sequencer, writes, errors } = createHarness({
+    planAction: () => plans.shift(),
+  });
+
+  sequencer.setUid('u1');
+  sequencer.handleSnapshot({ uid: 'u1', exists: true, fromCache: false, getData: () => ({}) });
+  sequencer.enqueue({ uid: 'u1', modify: {} });
+  sequencer.enqueue({ uid: 'u1', modify: {} });
+  sequencer.enqueue({ uid: 'u1', modify: {} });
+
+  assert.equal(writes.length, 1);
+  assert.deepEqual(errors, [
+    {
+      code: 'change/invalid-pointer',
+      message: 'Cannot apply change: change/invalid-pointer',
+    },
+  ]);
+});
+
+test('planning exceptions emit onChangeError and do not block later actions', () => {
+  const { sequencer, writes, errors } = createHarness({
+    planAction: ({ modify }) => {
+      if (modify.property === '/broken') {
+        throw new Error('planner exploded');
+      }
+      return {
+        kind: 'targeted-write',
+        update: { ok: true },
+        expectedDoc: { ok: true },
+      };
+    },
+  });
+
+  sequencer.setUid('u1');
+  sequencer.enqueue({ uid: 'u1', modify: { property: '/broken' } });
+  sequencer.enqueue({ uid: 'u1', modify: { property: '/ok' } });
+
+  assert.doesNotThrow(() => {
+    sequencer.handleSnapshot({
+      uid: 'u1',
+      exists: true,
+      fromCache: false,
+      getData: () => ({}),
+    });
+  });
+  assert.deepEqual(errors, [
+    { code: 'change/planning-failed', message: 'planner exploded' },
+  ]);
+  assert.equal(writes.length, 1);
+  assert.equal(sequencer.inspect().queueLength, 0);
+});
+
+test('a synchronous submit failure reports the error and leaves planningDoc unchanged', () => {
+  const errors = [];
+  const sequencer = createUserDocSequencer({
+    planAction: () => ({ kind: 'targeted-write', update: { a: 1 }, expectedDoc: { a: 1 } }),
+    submitWrite: () => {
+      throw new Error('boom');
+    },
+    readCache: () => Promise.reject(new Error('unused')),
+    onChangeError: (code, message) => errors.push({ code, message }),
+  });
+
+  sequencer.setUid('u1');
+  sequencer.handleSnapshot({ uid: 'u1', exists: true, fromCache: false, getData: () => ({ a: 0 }) });
+  sequencer.enqueue({ uid: 'u1', modify: {} });
+
+  assert.equal(errors.length, 1);
+  assert.deepEqual(sequencer.inspect().planningDoc, { a: 0 });
+  assert.equal(sequencer.inspect().unsettledCount, 0);
+});
+
+test('UID change resets state and never flushes old actions into the new user', () => {
+  const { sequencer, writes, errors } = createHarness({
+    planAction: () => ({ kind: 'targeted-write', update: { a: 1 }, expectedDoc: { a: 1 } }),
+  });
+
+  sequencer.setUid('u1');
+  sequencer.enqueue({ uid: 'u1', modify: {} }); // held: existence unknown
+
+  sequencer.setUid('u2');
+  sequencer.handleSnapshot({ uid: 'u2', exists: true, fromCache: false, getData: () => ({}) });
+  assert.equal(writes.length, 0, 'u1 action must not run for u2');
+  assert.equal(sequencer.inspect().queueLength, 0);
+
+  // Stale enqueue carrying the old uid is dropped with an error.
+  sequencer.enqueue({ uid: 'u1', modify: {} });
+  assert.equal(errors.at(-1).code, 'change/uid-mismatch');
+
+  // Stale snapshot for the old uid is ignored.
+  sequencer.handleSnapshot({ uid: 'u1', exists: true, fromCache: false, getData: () => ({ stale: 1 }) });
+  assert.deepEqual(sequencer.inspect().planningDoc, {});
+});
+
+test('resolving a prior UID write cannot settle or unblock the active UID', async () => {
+  const { sequencer, pending } = createHarness({
+    planAction: ({ modify }) => ({
+      kind: 'targeted-write',
+      update: { value: modify.value },
+      expectedDoc: { value: modify.value },
+    }),
+  });
+
+  sequencer.setUid('u1');
+  sequencer.handleSnapshot({ uid: 'u1', exists: true, fromCache: false, getData: () => ({}) });
+  sequencer.enqueue({ uid: 'u1', modify: { value: 'u1 optimistic' } });
+
+  sequencer.setUid('u2');
+  sequencer.handleSnapshot({ uid: 'u2', exists: true, fromCache: false, getData: () => ({}) });
+  sequencer.enqueue({ uid: 'u2', modify: { value: 'u2 optimistic' } });
+  assert.equal(sequencer.inspect().unsettledCount, 1);
+
+  pending[0].resolve();
+  await settle();
+  assert.equal(sequencer.inspect().unsettledCount, 1);
+
+  sequencer.handleSnapshot({
+    uid: 'u2',
+    exists: true,
+    fromCache: false,
+    getData: () => ({ value: 'u2 stale snapshot' }),
+  });
+  assert.deepEqual(sequencer.inspect().planningDoc, { value: 'u2 optimistic' });
+});
+
+test('rejecting a prior UID write cannot settle the active UID or report an error', async () => {
+  const { sequencer, errors, pending } = createHarness({
+    planAction: ({ modify }) => ({
+      kind: 'targeted-write',
+      update: { value: modify.value },
+      expectedDoc: { value: modify.value },
+    }),
+  });
+
+  sequencer.setUid('u1');
+  sequencer.handleSnapshot({ uid: 'u1', exists: true, fromCache: false, getData: () => ({}) });
+  sequencer.enqueue({ uid: 'u1', modify: { value: 'u1 optimistic' } });
+
+  sequencer.setUid('u2');
+  sequencer.handleSnapshot({ uid: 'u2', exists: true, fromCache: false, getData: () => ({}) });
+  sequencer.enqueue({ uid: 'u2', modify: { value: 'u2 optimistic' } });
+
+  const oldUserError = new Error('u1 write failed');
+  oldUserError.code = 'permission-denied';
+  pending[0].reject(oldUserError);
+  await settle();
+
+  assert.equal(sequencer.inspect().unsettledCount, 1);
+  assert.deepEqual(errors, []);
+});
+
+test('a rejection resumed after returning to the originating UID is still reported', async () => {
+  const { sequencer, errors, pending } = createHarness({
+    planAction: ({ modify }) => ({
+      kind: 'targeted-write',
+      update: { value: modify.value },
+      expectedDoc: { value: modify.value },
+    }),
+  });
+
+  sequencer.setUid('u1');
+  sequencer.handleSnapshot({ uid: 'u1', exists: true, fromCache: false, getData: () => ({}) });
+  sequencer.enqueue({ uid: 'u1', modify: { value: 'queued offline' } });
+
+  // Auth bounces to another user and back before the write settles; the
+  // offline queue then resumes u1's mutation and the server rejects it.
+  sequencer.setUid('u2');
+  sequencer.setUid('u1');
+
+  const rejection = Object.assign(new Error('denied'), { code: 'permission-denied' });
+  pending[0].reject(rejection);
+  await settle();
+
+  assert.equal(errors.at(-1)?.code, 'permission-denied');
+});
+
+test('write settlements are inert after dispose', async () => {
+  const { sequencer, errors, pending } = createHarness({
+    planAction: ({ modify }) => ({
+      kind: 'targeted-write',
+      update: { value: modify.value },
+      expectedDoc: { value: modify.value },
+    }),
+  });
+
+  sequencer.setUid('u1');
+  sequencer.handleSnapshot({ uid: 'u1', exists: true, fromCache: false, getData: () => ({}) });
+  sequencer.enqueue({ uid: 'u1', modify: { value: 1 } });
+  sequencer.enqueue({ uid: 'u1', modify: { value: 2 } });
+  sequencer.dispose();
+
+  pending[0].resolve();
+  pending[1].reject(new Error('disposed write failed'));
+  await settle();
+
+  assert.equal(sequencer.inspect().unsettledCount, 2);
+  assert.deepEqual(errors, []);
+});
+
+// Harness with controllable cache reads.
+const defaultRebasePlanAction = ({ modify, userDoc }) => ({
+  kind: 'targeted-write',
+  update: { [modify.key]: modify.value },
+  expectedDoc: { ...userDoc, [modify.key]: modify.value },
+});
+
+const createRebaseHarness = ({ planAction = defaultRebasePlanAction } = {}) => {
+  const writes = [];
+  const errors = [];
+  const pendingWrites = [];
+  const cacheReads = [];
+  const sequencer = createUserDocSequencer({
+    planAction,
+    submitWrite: (write) => {
+      writes.push(write);
+      return new Promise((resolve, reject) => {
+        pendingWrites.push({ resolve, reject });
+      });
+    },
+    readCache: () =>
+      new Promise((resolve, reject) => {
+        cacheReads.push({ resolve, reject });
+      }),
+    onChangeError: (code, message) => errors.push({ code, message }),
+  });
+  sequencer.setUid('u1');
+  sequencer.handleSnapshot({ uid: 'u1', exists: true, fromCache: false, getData: () => ({}) });
+  return { sequencer, writes, errors, pendingWrites, cacheReads };
+};
+
+test('atomic transforms rebase from Firestore local view before later actions', async () => {
+  const seen = [];
+  const h = createRebaseHarness({
+    planAction: ({ modify, userDoc }) => {
+      seen.push(userDoc);
+      if (modify.kind === 'transform') {
+        return {
+          kind: 'atomic-transform',
+          update: {},
+          // The JS planner cannot distinguish an encoded double 1 from an
+          // integer 1, so this prediction can differ from Firestore's view.
+          expectedDoc: { arr: [1] },
+        };
+      }
+      return {
+        kind: 'targeted-write',
+        update: { touched: true },
+        expectedDoc: { ...userDoc, touched: true },
+      };
+    },
+  });
+  h.sequencer.handleSnapshot({
+    uid: 'u1',
+    exists: true,
+    fromCache: false,
+    getData: () => ({ arr: [1] }),
+  });
+
+  h.sequencer.enqueue({ uid: 'u1', modify: { kind: 'transform' } });
+  h.sequencer.enqueue({ uid: 'u1', modify: { kind: 'follow-up' } });
+
+  assert.equal(h.writes.length, 1, 'follow-up waits for the local cache view');
+  await settle();
+  assert.equal(h.cacheReads.length, 1);
+
+  h.cacheReads[0].resolve({ exists: true, data: { arr: [1, 1] } });
+  await settle();
+
+  assert.equal(h.writes.length, 2);
+  assert.deepEqual(seen, [{ arr: [1] }, { arr: [1, 1] }]);
+});
+
+test('zero-count transition triggers a cache rebase that replaces planningDoc', async () => {
+  const h = createRebaseHarness();
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'a', value: 1 } });
+
+  h.pendingWrites[0].resolve();
+  await settle();
+  assert.equal(h.cacheReads.length, 1, 'rebase read scheduled at zero transition');
+
+  h.cacheReads[0].resolve({ exists: true, data: { a: 1, remote: 'merged' } });
+  await settle();
+  assert.deepEqual(h.sequencer.inspect().planningDoc, { a: 1, remote: 'merged' });
+  assert.equal(h.sequencer.inspect().rebaseInFlight, false);
+});
+
+test('an action arriving during a rebase is held, then planned from the rebased doc', async () => {
+  const h = createRebaseHarness();
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'a', value: 1 } });
+  h.pendingWrites[0].resolve();
+  await settle();
+
+  // New action while the cache read is in flight: no write yet.
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'b', value: 2 } });
+  assert.equal(h.writes.length, 1);
+  assert.equal(h.sequencer.inspect().queueLength, 1);
+
+  h.cacheReads[0].resolve({ exists: true, data: { a: 1 } });
+  await settle();
+
+  // The held action was planned from the rebased base.
+  assert.equal(h.writes.length, 2);
+  assert.deepEqual(h.sequencer.inspect().planningDoc, { a: 1, b: 2 });
+});
+
+test('actions arriving between a rejection and its rebase never plan from rejected state', async () => {
+  const h = createRebaseHarness();
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'a', value: 1 } });
+
+  const rejection = Object.assign(new Error('denied'), { code: 'permission-denied' });
+  h.pendingWrites[0].reject(rejection);
+  await settle();
+  assert.equal(h.cacheReads.length, 1, 'rejection schedules a rebase');
+
+  // Action arrives before the corrective cache read resolves: it must wait,
+  // otherwise it would be planned from a planningDoc containing the rejected
+  // mutation and the corrective result would then be discarded.
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'b', value: 2 } });
+  assert.equal(h.writes.length, 1, 'planning deferred until the rebase lands');
+
+  // Server view: the rejected write never applied.
+  h.cacheReads[0].resolve({ exists: true, data: {} });
+  await settle();
+
+  assert.equal(h.writes.length, 2);
+  assert.deepEqual(h.sequencer.inspect().planningDoc, { b: 2 });
+});
+
+test('a write rejection reports onChangeError and rebases even with later writes pending', async () => {
+  const h = createRebaseHarness();
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'a', value: 1 } });
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'b', value: 2 } });
+
+  const rejection = Object.assign(new Error('denied'), { code: 'permission-denied' });
+  h.pendingWrites[0].reject(rejection);
+  await settle();
+
+  assert.equal(h.errors.at(-1).code, 'permission-denied');
+  assert.equal(h.cacheReads.length, 1, 'rejection schedules an immediate rebase');
+
+  // Cache view: rejected mutation removed, remaining overlay (b) applied.
+  h.cacheReads[0].resolve({ exists: true, data: { b: 2 } });
+  await settle();
+  assert.deepEqual(h.sequencer.inspect().planningDoc, { b: 2 });
+});
+
+test('cache-read failure leaves planningDoc unchanged and does not block later actions', async () => {
+  const h = createRebaseHarness();
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'a', value: 1 } });
+  h.pendingWrites[0].resolve();
+  await settle();
+
+  h.cacheReads[0].reject(new Error('unavailable'));
+  await settle();
+  assert.deepEqual(h.sequencer.inspect().planningDoc, { a: 1 });
+  assert.equal(h.sequencer.inspect().rebaseInFlight, false);
+
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'c', value: 3 } });
+  assert.equal(h.writes.length, 2);
+});
+
+test('a cache result reporting exists=false transitions to known-missing', async () => {
+  const h = createRebaseHarness();
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'a', value: 1 } });
+  h.pendingWrites[0].resolve();
+  await settle();
+
+  h.cacheReads[0].resolve({ exists: false, data: undefined });
+  await settle();
+  assert.equal(h.sequencer.inspect().existence, 'missing');
+
+  // Subsequent actions are documented no-ops, not errors.
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'd', value: 4 } });
+  assert.equal(h.writes.length, 1);
+  assert.equal(h.errors.length, 0);
+});
+
+test('snapshots are ignored while writes are unsettled or a rebase is in flight', async () => {
+  const h = createRebaseHarness();
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'a', value: 1 } });
+
+  // Unsettled write: snapshot must not regress the optimistic chain.
+  h.sequencer.handleSnapshot({ uid: 'u1', exists: true, fromCache: false, getData: () => ({ old: true }) });
+  assert.deepEqual(h.sequencer.inspect().planningDoc, { a: 1 });
+
+  h.pendingWrites[0].resolve();
+  await settle();
+  // Rebase in flight: still ignored.
+  h.sequencer.handleSnapshot({ uid: 'u1', exists: true, fromCache: false, getData: () => ({ old: true }) });
+  assert.deepEqual(h.sequencer.inspect().planningDoc, { a: 1 });
+
+  h.cacheReads[0].resolve({ exists: true, data: { a: 1 } });
+  await settle();
+  // Idle again: snapshots refresh the base.
+  h.sequencer.handleSnapshot({ uid: 'u1', exists: true, fromCache: false, getData: () => ({ fresh: 1 }) });
+  assert.deepEqual(h.sequencer.inspect().planningDoc, { fresh: 1 });
+});
+
+test('UID change invalidates an in-flight rebase', async () => {
+  const h = createRebaseHarness();
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'a', value: 1 } });
+  h.pendingWrites[0].resolve();
+  await settle();
+
+  h.sequencer.setUid('u2');
+  h.cacheReads[0].resolve({ exists: true, data: { a: 1 } });
+  await settle();
+
+  assert.equal(h.sequencer.inspect().existence, 'unknown');
+  assert.equal(h.sequencer.inspect().planningDoc, null);
+});
+
+test('an older rebase cannot apply or clear a newer in-flight rebase', async () => {
+  const h = createRebaseHarness();
+  // Two writes issued while idle, both left pending.
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'a', value: 1 } });
+  h.sequencer.enqueue({ uid: 'u1', modify: { key: 'b', value: 2 } });
+
+  const rejection = Object.assign(new Error('denied'), { code: 'permission-denied' });
+  h.pendingWrites[0].reject(rejection);
+  await settle();
+  assert.equal(h.cacheReads.length, 1, 'first rejection schedules a rebase');
+
+  h.pendingWrites[1].reject(rejection);
+  await settle();
+  assert.equal(h.cacheReads.length, 2, 'second rejection schedules a newer rebase');
+
+  h.cacheReads[0].resolve({ exists: true, data: { stale: true } });
+  await settle();
+  assert.deepEqual(h.sequencer.inspect().planningDoc, { a: 1, b: 2 });
+  assert.equal(h.sequencer.inspect().rebaseInFlight, true);
+
+  h.sequencer.handleSnapshot({
+    uid: 'u1',
+    exists: true,
+    fromCache: false,
+    getData: () => ({ snapshotMustNotWin: true }),
+  });
+  assert.deepEqual(h.sequencer.inspect().planningDoc, { a: 1, b: 2 });
+
+  h.cacheReads[1].resolve({ exists: true, data: { current: true } });
+  await settle();
+  assert.deepEqual(h.sequencer.inspect().planningDoc, { current: true });
+  assert.equal(h.sequencer.inspect().rebaseInFlight, false);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,16 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@apidevtools/json-schema-ref-parser@^9.0.3":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz#8ff5386b365d4c9faa7c8b566ff16a46a577d9b8"
+  integrity sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==
+  dependencies:
+    "@jsdevtools/ono" "^7.1.3"
+    "@types/json-schema" "^7.0.6"
+    call-me-maybe "^1.0.1"
+    js-yaml "^4.1.0"
+
 "@babel/code-frame@^7.0.0":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -340,6 +350,30 @@
     crelt "^1.0.6"
     style-mod "^4.1.0"
     w3c-keyname "^2.2.4"
+
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
+"@colors/colors@1.6.0", "@colors/colors@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.6.0.tgz#ec6cd237440700bc23ca23087f513c75508958b0"
+  integrity sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==
+
+"@dabh/diagnostics@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.8.tgz#ead97e72ca312cf0e6dd7af0d300b58993a31a5e"
+  integrity sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==
+  dependencies:
+    "@so-ric/colorspace" "^1.1.6"
+    enabled "2.0.x"
+    kuler "^2.0.0"
+
+"@electric-sql/pglite@^0.2.16":
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/@electric-sql/pglite/-/pglite-0.2.17.tgz#23d53a9b7ddd1590d59d7c701aba23b037f08108"
+  integrity sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw==
 
 "@esbuild/aix-ppc64@0.24.2":
   version "0.24.2"
@@ -930,6 +964,74 @@
   resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-2.2.0.tgz#ba6e12fe64ff7fd160be392007c47d24b7ae5c75"
   integrity sha512-+Az7tR1av1DHZu9668D8uh9atT6vp+FFmEF8BrEssv0OqzpVjpVBGVmcgPzQP8k2PQjVlm/h2w8cTt0knn132w==
 
+"@google-cloud/cloud-sql-connector@1.8.2", "@google-cloud/cloud-sql-connector@^1.3.3":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@google-cloud/cloud-sql-connector/-/cloud-sql-connector-1.8.2.tgz#385e43e30efa8aaa7f0dcdd68fdcec07d620c8a8"
+  integrity sha512-B9LEMYIO3nJxZ2RsHM9ArYP5cElZf+EZHYZHeqx2tSCucA05s+w33nw9jibIvbs8agB/YubGbVfAiYKBAUh3DQ==
+  dependencies:
+    "@googleapis/sqladmin" "^31.0.0"
+    gaxios "^7.0.0"
+    google-auth-library "^10.0.0"
+    p-throttle "^7.0.0"
+
+"@google-cloud/paginator@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@google-cloud/paginator/-/paginator-5.0.2.tgz#86ad773266ce9f3b82955a8f75e22cd012ccc889"
+  integrity sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==
+  dependencies:
+    arrify "^2.0.0"
+    extend "^3.0.2"
+
+"@google-cloud/precise-date@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/precise-date/-/precise-date-4.0.0.tgz#e179893a3ad628b17a6fabdfcc9d468753aac11a"
+  integrity sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA==
+
+"@google-cloud/projectify@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/projectify/-/projectify-4.0.0.tgz#d600e0433daf51b88c1fa95ac7f02e38e80a07be"
+  integrity sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==
+
+"@google-cloud/promisify@~4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-4.0.0.tgz#a906e533ebdd0f754dca2509933334ce58b8c8b1"
+  integrity sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==
+
+"@google-cloud/pubsub@^4.5.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/pubsub/-/pubsub-4.11.0.tgz#cafbd135a66585b32a124d388169a06992e75c9c"
+  integrity sha512-xWxJAlyUGd6OPp97u8maMcI3xVXuHjxfwh6Dr7P/P+6NK9o446slJobsbgsmK0xKY4nTK8m5uuJrhEKapfZSmQ==
+  dependencies:
+    "@google-cloud/paginator" "^5.0.0"
+    "@google-cloud/precise-date" "^4.0.0"
+    "@google-cloud/projectify" "^4.0.0"
+    "@google-cloud/promisify" "~4.0.0"
+    "@opentelemetry/api" "~1.9.0"
+    "@opentelemetry/semantic-conventions" "~1.30.0"
+    arrify "^2.0.0"
+    extend "^3.0.2"
+    google-auth-library "^9.3.0"
+    google-gax "^4.3.3"
+    heap-js "^2.2.0"
+    is-stream-ended "^0.1.4"
+    lodash.snakecase "^4.1.1"
+    p-defer "^3.0.0"
+
+"@googleapis/sqladmin@^31.0.0":
+  version "31.1.0"
+  resolved "https://registry.yarnpkg.com/@googleapis/sqladmin/-/sqladmin-31.1.0.tgz#facc747c6c2b2421caa12f232649b9f424efe7c7"
+  integrity sha512-k4lXSFCFuZmWtYuW/OH/PcHimZP5P/uDLK0+ACbgoZFB8qmlgcyF0531aJt6JHIdBwCRlHXZlMW4LDC5Gqra5w==
+  dependencies:
+    googleapis-common "^8.0.2-rc.0"
+
+"@grpc/grpc-js@^1.10.9":
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.4.tgz#e73ff57d97802f063999545f43ebb2b1eca65d9d"
+  integrity sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==
+  dependencies:
+    "@grpc/proto-loader" "^0.8.0"
+    "@js-sdsl/ordered-map" "^4.4.2"
+
 "@grpc/grpc-js@~1.9.0":
   version "1.9.15"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.15.tgz#433d7ac19b1754af690ea650ab72190bd700739b"
@@ -937,6 +1039,16 @@
   dependencies:
     "@grpc/proto-loader" "^0.7.8"
     "@types/node" ">=12.12.47"
+
+"@grpc/proto-loader@^0.7.13":
+  version "0.7.15"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.15.tgz#4cdfbf35a35461fc843abe8b9e2c0770b5095e60"
+  integrity sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    long "^5.0.0"
+    protobufjs "^7.2.5"
+    yargs "^17.7.2"
 
 "@grpc/proto-loader@^0.7.8":
   version "0.7.13"
@@ -946,6 +1058,16 @@
     lodash.camelcase "^4.3.0"
     long "^5.0.0"
     protobufjs "^7.2.5"
+    yargs "^17.7.2"
+
+"@grpc/proto-loader@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.8.1.tgz#5a6b290ccbfb1ae2f6775afb74e9898bd8c5d4e8"
+  integrity sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    long "^5.0.0"
+    protobufjs "^7.5.5"
     yargs "^17.7.2"
 
 "@headlessui/react@^2.0.4":
@@ -968,6 +1090,26 @@
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.3.tgz#f060bf6eaafae4d56a7dac618980838b0696e2ab"
   integrity sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==
+
+"@inquirer/external-editor@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/external-editor/-/external-editor-1.0.3.tgz#c23988291ee676290fdab3fd306e64010a6d13b8"
+  integrity sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==
+  dependencies:
+    chardet "^2.1.1"
+    iconv-lite "^0.7.0"
+
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
 "@jest/types@^24.9.0":
   version "24.9.0"
@@ -1009,6 +1151,16 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@js-sdsl/ordered-map@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
+  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
+
+"@jsdevtools/ono@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
+  integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
 "@lezer/common@^1.0.0", "@lezer/common@^1.1.0", "@lezer/common@^1.2.0", "@lezer/common@^1.3.0":
   version "1.3.0"
@@ -1068,6 +1220,24 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
+
+"@npmcli/agent@^2.0.0":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@npmcli/agent/-/agent-2.2.2.tgz#967604918e62f620a648c7975461c9c9e74fc5d5"
+  integrity sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==
+  dependencies:
+    agent-base "^7.1.0"
+    http-proxy-agent "^7.0.0"
+    https-proxy-agent "^7.0.1"
+    lru-cache "^10.0.1"
+    socks-proxy-agent "^8.0.3"
+
+"@npmcli/fs@^3.1.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-3.1.1.tgz#59cdaa5adca95d135fc00f2bb53f5771575ce726"
+  integrity sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==
+  dependencies:
+    semver "^7.3.5"
 
 "@octokit/auth-token@^2.4.0":
   version "2.4.0"
@@ -1166,6 +1336,42 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@opentelemetry/api@~1.9.0":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
+  integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+
+"@opentelemetry/semantic-conventions@~1.30.0":
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz#3a42c4c475482f2ec87c12aad98832dc0087dc9a"
+  integrity sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@pnpm/config.env-replace@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz#ab29da53df41e8948a00f2433f085f54de8b3a4c"
+  integrity sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==
+
+"@pnpm/network.ca-file@^1.0.1":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz#2ab05e09c1af0cdf2fcf5035bea1484e222f7983"
+  integrity sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==
+  dependencies:
+    graceful-fs "4.2.10"
+
+"@pnpm/npm-conf@^3.0.2":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz#17b59982126c86294a8d248aa1d7b185f2df6484"
+  integrity sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==
+  dependencies:
+    "@pnpm/config.env-replace" "^1.1.0"
+    "@pnpm/network.ca-file" "^1.0.1"
+    config-chain "^1.1.11"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -1181,10 +1387,20 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
   integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
 
+"@protobufjs/codegen@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
+  integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
+
 "@protobufjs/eventemitter@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
   integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+
+"@protobufjs/eventemitter@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz#d512cb26c0ae026091ee2c1167f1be6faf5c842a"
+  integrity sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==
 
 "@protobufjs/fetch@^1.1.0":
   version "1.1.0"
@@ -1193,6 +1409,13 @@
   dependencies:
     "@protobufjs/aspromise" "^1.1.1"
     "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/fetch@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.1.tgz#4d6fc00c8fb64016a5c81b469d549046350f1065"
+  integrity sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
 
 "@protobufjs/float@^1.0.2":
   version "1.0.2"
@@ -1218,6 +1441,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
+"@protobufjs/utf8@^1.1.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.2.tgz#78d476333d85d5b1c792e257bca74ba080da49a4"
+  integrity sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==
 
 "@radix-ui/primitive@1.1.3":
   version "1.1.3"
@@ -1626,6 +1854,19 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-2.1.0.tgz#6ad4ca610f696098e92954ab431ff83bea0ce13f"
   integrity sha512-lXKXfypKo644k4Da4yXkPCrwcvn6SlUW2X2zFbuflKHNjf0w9htru01bo26uMhleMXsDmnZ12eJLdrAZa9MANg==
 
+"@sindresorhus/is@^4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
+  integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
+
+"@so-ric/colorspace@^1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@so-ric/colorspace/-/colorspace-1.1.6.tgz#62515d8b9f27746b76950a83bde1af812d91923b"
+  integrity sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==
+  dependencies:
+    color "^5.0.2"
+    text-hex "1.0.x"
+
 "@swc/helpers@^0.5.0":
   version "0.5.17"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.17.tgz#5a7be95ac0f0bf186e7e6e890e7a6f6cda6ce971"
@@ -1647,7 +1888,7 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@tailwindcss/postcss7-compat@^2.1.0":
+"@tailwindcss/postcss7-compat@^2.1.0", "tailwindcss@npm:@tailwindcss/postcss7-compat":
   version "2.2.17"
   resolved "https://registry.yarnpkg.com/@tailwindcss/postcss7-compat/-/postcss7-compat-2.2.17.tgz#dc78f3880a2af84163150ff426a39e42b9ae8922"
   integrity sha512-3h2svqQAqYHxRZ1KjsJjZOVTQ04m29LjfrLjXyZZEJuvUuJN+BCIF9GI8vhE1s0plS0mogd6E6YLg6mu4Wv/Vw==
@@ -1741,6 +1982,16 @@
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-7.2.1.tgz#2ad4e844175a3738cb9e7064be5ea070b8863a1c"
   integrity sha512-oZ0Ib5I4Z2pUEcoo95cT1cr6slco9WY7yiPpG+RGNkj8YcYgJnM7pXmYmorNOReh8MIGcKSqXyeGjxnr8YiZbA==
 
+"@tootallnate/once@2":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.1.tgz#35adc6222e3662fa2222ce123b961476a746b9ea"
+  integrity sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==
+
+"@tootallnate/quickjs-emscripten@^0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
+  integrity sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==
+
 "@types/cacheable-request@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
@@ -1750,6 +2001,11 @@
     "@types/keyv" "*"
     "@types/node" "*"
     "@types/responselike" "*"
+
+"@types/caseless@*":
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.5.tgz#db9468cb1b1b5a925b8f34822f1669df0c5472f5"
+  integrity sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -1799,6 +2055,11 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/json-schema@^7.0.6":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -1810,6 +2071,11 @@
   integrity sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==
   dependencies:
     "@types/node" "*"
+
+"@types/long@^4.0.0":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
+  integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
 "@types/node@*":
   version "13.7.1"
@@ -1851,6 +2117,16 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/request@^2.48.8":
+  version "2.48.13"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.13.tgz#abdf4256524e801ea8fdda54320f083edb5a6b80"
+  integrity sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==
+  dependencies:
+    "@types/caseless" "*"
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    form-data "^2.5.5"
+
 "@types/responselike@*":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
@@ -1872,6 +2148,16 @@
   dependencies:
     "@types/react-dom" "*"
     "@types/testing-library__dom" "*"
+
+"@types/tough-cookie@*":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
+  integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
+
+"@types/triple-beam@^1.3.2":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.5.tgz#74fef9ffbaa198eb8b588be029f38b00299caa2c"
+  integrity sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -1920,6 +2206,26 @@
     "@babel/plugin-transform-react-jsx-source" "^7.14.5"
     "@rollup/pluginutils" "^4.1.1"
     react-refresh "^0.10.0"
+
+abbrev@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
+  integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
+
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
+accepts@~1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
+  dependencies:
+    mime-types "~2.1.34"
+    negotiator "0.6.3"
 
 acorn-jsx@^5.2.0:
   version "5.3.2"
@@ -2004,6 +2310,40 @@ ag-grid-react@~34.0.0:
     ag-grid-community "34.0.2"
     prop-types "^15.8.1"
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
+agent-base@^7.1.0, agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
+
+aggregate-error@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
+  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
+  dependencies:
+    clean-stack "^2.0.0"
+    indent-string "^4.0.0"
+
+ajv-formats@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
+  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
+  dependencies:
+    ajv "^8.0.0"
+
+ajv-formats@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv@^6.10.0, ajv@^6.10.2:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -2013,6 +2353,16 @@ ajv@^6.10.0, ajv@^6.10.2:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.17.1, ajv@^8.3.0:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
+  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 ansi-align@^3.0.0:
   version "3.0.0"
@@ -2028,6 +2378,20 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.8.1"
 
+ansi-escapes@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
+  dependencies:
+    type-fest "^0.21.3"
+
+ansi-escapes@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.3.0.tgz#5395bb74b2150a4a1d6e3c2565f4aeca78d28627"
+  integrity sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==
+  dependencies:
+    environment "^1.0.0"
+
 ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
@@ -2042,6 +2406,11 @@ ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-regex@^6.1.0, ansi-regex@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -2065,6 +2434,16 @@ ansi-styles@^4.1.0:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
 
+ansi-styles@^6.1.0:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
+
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
+
 anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
@@ -2072,6 +2451,32 @@ anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+archiver-utils@^5.0.0, archiver-utils@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-5.0.2.tgz#63bc719d951803efc72cf961a56ef810760dd14d"
+  integrity sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==
+  dependencies:
+    glob "^10.0.0"
+    graceful-fs "^4.2.0"
+    is-stream "^2.0.1"
+    lazystream "^1.0.0"
+    lodash "^4.17.15"
+    normalize-path "^3.0.0"
+    readable-stream "^4.0.0"
+
+archiver@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/archiver/-/archiver-7.0.1.tgz#c9d91c350362040b8927379c7aa69c0655122f61"
+  integrity sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==
+  dependencies:
+    archiver-utils "^5.0.2"
+    async "^3.2.4"
+    buffer-crc32 "^1.0.0"
+    readable-stream "^4.0.0"
+    readdir-glob "^1.1.2"
+    tar-stream "^3.0.0"
+    zip-stream "^6.0.1"
 
 arg@^5.0.1:
   version "5.0.2"
@@ -2125,6 +2530,11 @@ array-buffer-byte-length@^1.0.2:
   dependencies:
     call-bound "^1.0.3"
     is-array-buffer "^3.0.5"
+
+array-flatten@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+  integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
 
 array-includes@^3.1.6:
   version "3.1.8"
@@ -2260,6 +2670,16 @@ arraybuffer.prototype.slice@^1.0.4:
     get-intrinsic "^1.2.6"
     is-array-buffer "^3.0.4"
 
+arrify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
+  integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
+
+as-array@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/as-array/-/as-array-2.0.0.tgz#4f04805d87f8fce8e511bc2108f8e5e3a287d547"
+  integrity sha512-1Sd1LrodN0XYxYeZcN1J4xYZvmvTwD5tDWaPUGPIzH1mFsmzsPnVtd2exWhecMjtZk/wYWjNZJiD3b1SLCeJqg==
+
 asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
@@ -2274,6 +2694,13 @@ ast-types-flow@^0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.8.tgz#0a85e1c92695769ac13a428bb653e7538bea27d6"
   integrity sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==
+
+ast-types@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.4.tgz#ee0d77b343263965ecc3fb62da16e7222b2b6782"
+  integrity sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==
+  dependencies:
+    tslib "^2.0.1"
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -2290,12 +2717,22 @@ async-generator-function@^1.0.0:
   resolved "https://registry.yarnpkg.com/async-generator-function/-/async-generator-function-1.0.0.tgz#9bcc76d7fd147171e7ead5d2a2cfc3579c99f28e"
   integrity sha512-+NAXNqgCrB95ya4Sr66i1CL2hqLVckAk7xwRYWdcm39/ELQ6YNn1aw5r0bdQtqNZgQpEWzc5yc/igXc7aL5SLA==
 
+async-lock@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/async-lock/-/async-lock-1.4.1.tgz#56b8718915a9b68b10fce2f2a9a3dddf765ef53f"
+  integrity sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==
+
 async-retry@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.1.tgz#139f31f8ddce50c0870b0ba558a6079684aaed55"
   integrity sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==
   dependencies:
     retry "0.12.0"
+
+async@^3.2.3, async@^3.2.4, async@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
+  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -2337,30 +2774,128 @@ axobject-query@^4.1.0:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
   integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
 
+b4a@^1.6.4, b4a@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.8.1.tgz#7f16334ca80127aeb26064a28841acbf174840a4"
+  integrity sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+bare-events@^2.5.4, bare-events@^2.7.0:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.9.1.tgz#5c86616966343bcb03a1b3155feab253eadbf349"
+  integrity sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==
+
+bare-fs@^4.5.5:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/bare-fs/-/bare-fs-4.7.4.tgz#435087d42477f067eddf3c2c746e74e9db6177bc"
+  integrity sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==
+  dependencies:
+    bare-events "^2.5.4"
+    bare-path "^3.0.0"
+    bare-stream "^2.6.4"
+    bare-url "^2.2.2"
+    fast-fifo "^1.3.2"
+
+bare-path@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/bare-path/-/bare-path-3.1.1.tgz#d4a207c088609b4663a7556a46a97342398bf7e2"
+  integrity sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==
+
+bare-stream@^2.6.4:
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/bare-stream/-/bare-stream-2.13.3.tgz#f6186c7cbb4bbf53a4560f35e48b16373ba51ce6"
+  integrity sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==
+  dependencies:
+    b4a "^1.8.1"
+    streamx "^2.25.0"
+    teex "^1.0.1"
+
+bare-url@^2.2.2:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/bare-url/-/bare-url-2.4.5.tgz#50d205f8f2724eec60fd091ba9cebd675fca63aa"
+  integrity sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==
+  dependencies:
+    bare-path "^3.0.0"
 
 base64-arraybuffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
   integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
 
+base64-js@^1.3.0, base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 baseline-browser-mapping@^2.8.25:
   version "2.8.28"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.8.28.tgz#9ef511f5a7c19d74a94cafcbf951608398e9bdb3"
   integrity sha512-gYjt7OIqdM0PcttNYP2aVrr2G0bMALkBaoehD4BuRGjAOtipg0b6wHg1yNL+s5zSnLZZrGHOw4IrND8CD+3oIQ==
+
+basic-auth-connect@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/basic-auth-connect/-/basic-auth-connect-1.1.0.tgz#b44af37d5b3bd7561b56491e58cf26ae1578f0c7"
+  integrity sha512-rKcWjfiRZ3p5WS9e5q6msXa07s6DaFAMXoyowV+mb2xQG+oYdw2QEUyKi0Xp95JvXzShlM+oGy5QuqSK6TfC1Q==
+  dependencies:
+    tsscmp "^1.0.6"
+
+basic-auth@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
+
+basic-ftp@^5.0.2:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.3.1.tgz#3148ee9af43c0522514a4f973fecb1d3cbb6d71e"
+  integrity sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==
 
 before-after-hook@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
+bignumber.js@^9.0.0:
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.3.1.tgz#759c5aaddf2ffdc4f154f7b493e1c8770f88c4d7"
+  integrity sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==
+
 binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
+
+bl@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
+body-parser@^1.18.3, body-parser@^1.19.0, body-parser@~1.20.5:
+  version "1.20.6"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.6.tgz#60c789c78e0992d906da0a29d71ae01d15c1ed76"
+  integrity sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==
+  dependencies:
+    bytes "~3.1.2"
+    content-type "~1.0.5"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "~1.2.0"
+    http-errors "~2.0.1"
+    iconv-lite "~0.4.24"
+    on-finished "~2.4.1"
+    qs "~6.15.1"
+    raw-body "~2.5.3"
+    type-is "~1.6.18"
+    unpipe "~1.0.0"
 
 boxen@^4.2.0:
   version "4.2.0"
@@ -2376,6 +2911,20 @@ boxen@^4.2.0:
     type-fest "^0.8.1"
     widest-line "^3.1.0"
 
+boxen@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-5.1.2.tgz#788cb686fc83c1f486dfa8a40c68fc2b831d2b50"
+  integrity sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==
+  dependencies:
+    ansi-align "^3.0.0"
+    camelcase "^6.2.0"
+    chalk "^4.1.0"
+    cli-boxes "^2.2.1"
+    string-width "^4.2.2"
+    type-fest "^0.20.2"
+    widest-line "^3.1.0"
+    wrap-ansi "^7.0.0"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -2383,6 +2932,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1, brace-expansion@^2.0.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
+  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^3.0.1:
   version "3.0.2"
@@ -2419,10 +2975,54 @@ browserslist@^4.24.0:
     node-releases "^2.0.19"
     update-browserslist-db "^1.1.1"
 
-bytes@^3.0.0:
+buffer-crc32@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-1.0.0.tgz#a10993b9055081d55304bd9feb4a072de179f405"
+  integrity sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==
+
+buffer-equal-constant-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
+
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
+bytes@3.1.2, bytes@^3.0.0, bytes@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
+
+cacache@^18.0.0:
+  version "18.0.4"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-18.0.4.tgz#4601d7578dadb59c66044e157d02a3314682d6a5"
+  integrity sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==
+  dependencies:
+    "@npmcli/fs" "^3.1.0"
+    fs-minipass "^3.0.0"
+    glob "^10.2.2"
+    lru-cache "^10.0.1"
+    minipass "^7.0.3"
+    minipass-collect "^2.0.1"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    p-map "^4.0.0"
+    ssri "^10.0.0"
+    tar "^6.1.11"
+    unique-filename "^3.0.0"
 
 cacheable-lookup@^2.0.0:
   version "2.0.0"
@@ -2494,6 +3094,11 @@ call-bound@^1.0.2, call-bound@^1.0.3, call-bound@^1.0.4:
     call-bind-apply-helpers "^1.0.2"
     get-intrinsic "^1.3.0"
 
+call-me-maybe@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.2.tgz#03f964f19522ba643b1b0693acb9152fe2074baa"
+  integrity sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -2508,6 +3113,11 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+camelcase@^6.2.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001754:
   version "1.0.30001754"
@@ -2536,7 +3146,7 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.1.0, chalk@^4.1.2:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2544,17 +3154,32 @@ chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^5.4.1:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
+  integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
+
 changelog-filename-regex@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/changelog-filename-regex/-/changelog-filename-regex-1.1.2.tgz#19e98e38248cff0c1cf3ae3bf51bfb22c48592d6"
   integrity sha512-kpOfKlZ9x2UpeC4at6FAXHLKfi/JEUqUqkPCb1JUCa5FnNbJIzOHRM9RfeQ1QDcpj+Gxuc/UoHqASgmEeFDejQ==
+
+char-regex@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
+  integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-chokidar@^3.5.2:
+chardet@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-2.2.0.tgz#005d664f2cbd4961888d2e2c32c5a69e59d8eec4"
+  integrity sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==
+
+chokidar@^3.5.2, chokidar@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
@@ -2569,10 +3194,22 @@ chokidar@^3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+cjson@^0.3.1:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/cjson/-/cjson-0.3.3.tgz#a92d9c786e5bf9b930806329ee05d5d3261b4afa"
+  integrity sha512-yKNcXi/Mvi5kb1uK0sahubYiyfUO2EUgOp4NcY9+8NX5Xmc+4yeNogZuLFkpLBBj7/QI9MjRUIuXrV9XOw5kVg==
+  dependencies:
+    json-parse-helpfulerror "^1.0.3"
 
 class-variance-authority@^0.7.1:
   version "0.7.1"
@@ -2586,10 +3223,20 @@ classnames@^2.2.5:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
+clean-stack@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+
 cli-boxes@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz#538ecae8f9c6ca508e3c3c95b453fe93cb4c168d"
   integrity sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==
+
+cli-boxes@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
+  integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -2598,10 +3245,36 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-highlight@^2.1.11:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-2.1.11.tgz#49736fa452f0aaf4fae580e30acb26828d2dc1bf"
+  integrity sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==
+  dependencies:
+    chalk "^4.0.0"
+    highlight.js "^10.7.1"
+    mz "^2.4.0"
+    parse5 "^5.1.1"
+    parse5-htmlparser2-tree-adapter "^6.0.0"
+    yargs "^16.0.0"
+
 cli-spinners@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.2.0.tgz#e8b988d9206c692302d8ee834e7a85c0144d8f77"
   integrity sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==
+
+cli-spinners@^2.5.0:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.2.tgz#1773a8f4b9c4d6ac31563df53b3fc1d79462fe41"
+  integrity sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==
+
+cli-table3@0.6.5, cli-table3@^0.6.5:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.5.tgz#013b91351762739c16a9567c21a04632e449bf2f"
+  integrity sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -2612,6 +3285,15 @@ cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -2676,6 +3358,13 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
+color-convert@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-3.1.3.tgz#db6627b97181cb8facdfce755ae26f97ab0711f1"
+  integrity sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==
+  dependencies:
+    color-name "^2.0.0"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
@@ -2686,6 +3375,11 @@ color-name@^1.0.0, color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+color-name@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-2.1.0.tgz#0b677385c1c4b4edfdeaf77e38fa338e3a40b693"
+  integrity sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==
+
 color-string@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
@@ -2693,6 +3387,13 @@ color-string@^1.9.0:
   dependencies:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
+
+color-string@^2.1.3:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-2.1.4.tgz#9dcf566ff976e23368c8bd673f5c35103ab41058"
+  integrity sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==
+  dependencies:
+    color-name "^2.0.0"
 
 color@^4.0.1:
   version "4.2.3"
@@ -2702,6 +3403,19 @@ color@^4.0.1:
     color-convert "^2.0.1"
     color-string "^1.9.0"
 
+color@^5.0.2:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-5.0.3.tgz#f79390b1b778e222ffbb54304d3dbeaef633f97f"
+  integrity sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==
+  dependencies:
+    color-convert "^3.1.3"
+    color-string "^2.1.3"
+
+colorette@^2.0.19:
+  version "2.0.20"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
+  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -2709,20 +3423,69 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0:
+commander@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
+commander@^2.11.0, commander@^2.19.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
+  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
 commander@^8.0.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
+compress-commons@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-6.0.2.tgz#26d31251a66b9d6ba23a84064ecd3a6a71d2609e"
+  integrity sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==
+  dependencies:
+    crc-32 "^1.2.0"
+    crc32-stream "^6.0.0"
+    is-stream "^2.0.1"
+    normalize-path "^3.0.0"
+    readable-stream "^4.0.0"
+
+compressible@~2.0.18:
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
+  integrity sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==
+  dependencies:
+    mime-db ">= 1.43.0 < 2"
+
+compression@^1.7.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.8.1.tgz#4a45d909ac16509195a9a28bd91094889c180d79"
+  integrity sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==
+  dependencies:
+    bytes "3.1.2"
+    compressible "~2.0.18"
+    debug "2.6.9"
+    negotiator "~0.6.4"
+    on-headers "~1.1.0"
+    safe-buffer "5.2.1"
+    vary "~1.1.2"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+config-chain@^1.1.11:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
+  integrity sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
 
 configstore@^5.0.1:
   version "5.0.1"
@@ -2741,10 +3504,42 @@ confusing-browser-globals@^1.0.10:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
   integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
 
+connect@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/connect/-/connect-3.7.0.tgz#5d49348910caa5e07a01800b030d0c35f20484f8"
+  integrity sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==
+  dependencies:
+    debug "2.6.9"
+    finalhandler "1.1.2"
+    parseurl "~1.3.3"
+    utils-merge "1.0.1"
+
+content-disposition@~0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
+  integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
+  dependencies:
+    safe-buffer "5.2.1"
+
+content-type@^1.0.4, content-type@~1.0.4, content-type@~1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
+  integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
+
 convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cookie-signature@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.7.tgz#ab5dd7ab757c54e60f37ef6550f481c426d10454"
+  integrity sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==
+
+cookie@~0.7.1:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 core-js@^3.36.0:
   version "3.45.1"
@@ -2755,6 +3550,19 @@ core-js@^3.5.0:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
   integrity sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+cors@^2.8.5:
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.6.tgz#ff5dd69bd95e547503820d29aba4f8faf8dfec96"
+  integrity sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 cosmiconfig@6.0.0:
   version "6.0.0"
@@ -2777,6 +3585,19 @@ cosmiconfig@^7.0.1:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+crc-32@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
+  integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
+
+crc32-stream@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-6.0.0.tgz#8529a3868f8b27abb915f6c3617c0fadedbf9430"
+  integrity sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==
+  dependencies:
+    crc-32 "^1.2.0"
+    readable-stream "^4.0.0"
 
 create-react-context@^0.3.0:
   version "0.3.0"
@@ -2829,7 +3650,7 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cross-spawn@^7.0.1:
+cross-spawn@^7.0.1, cross-spawn@^7.0.5, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -2890,10 +3711,25 @@ csstype@^2.2.0:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
   integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
 
+csv-parse@^5.0.4:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-5.6.0.tgz#219beace2a3e9f28929999d2aa417d3fb3071c7f"
+  integrity sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==
+
 damerau-levenshtein@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
+
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
+data-uri-to-buffer@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz#8a58bb67384b261a38ef18bea1810cb01badd28b"
+  integrity sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==
 
 data-view-buffer@^1.0.1:
   version "1.0.1"
@@ -2961,6 +3797,20 @@ date-fns@^2.30.0:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
+debug@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@4, debug@^4.0.1, debug@^4.3.4, debug@^4.3.6, debug@^4.4.0:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 debug@4.1.1, debug@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -2968,19 +3818,19 @@ debug@4.1.1, debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
+debug@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.0.1:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
 
 debug@^4.3.1:
   version "4.4.0"
@@ -3013,6 +3863,13 @@ decompress-response@^5.0.0:
   dependencies:
     mimic-response "^2.0.0"
 
+deep-equal-in-any-order@^2.0.6:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/deep-equal-in-any-order/-/deep-equal-in-any-order-2.2.0.tgz#5dd191574852dfb66a7f883e6aa506a9a6c704bf"
+  integrity sha512-lUYf3Oz/HrPcNmKe+S+QSdY5/hzKleftcFBWLwbHNZ5007RUKgN0asWlAHuQGvT9djYd9PYQFiu0TyNS+h3j/g==
+  dependencies:
+    sort-any "^4.0.0"
+
 deep-equal@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
@@ -3030,7 +3887,12 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deep-is@~0.1.3:
+deep-freeze@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/deep-freeze/-/deep-freeze-0.0.1.tgz#3a0b0005de18672819dfd38cd31f91179c893e84"
+  integrity sha512-Z+z8HiAvsGwmjqlphnHW5oz6yWlOwu6EQfFTjmeTWlDeda3FS2yv3jhq35TX/ewmsnqB+RX2IdsIOyjJCQN5tg==
+
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
@@ -3087,10 +3949,24 @@ defined@^1.0.0:
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.1.tgz#c0b9db27bfaffd95d6f61399419b893df0f91ebf"
   integrity sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==
 
+degenerator@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-5.0.1.tgz#9403bf297c6dad9a1ece409b37db27954f91f2f5"
+  integrity sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==
+  dependencies:
+    ast-types "^0.13.4"
+    escodegen "^2.1.0"
+    esprima "^4.0.1"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 deprecated-obj@1.0.1:
   version "1.0.1"
@@ -3104,6 +3980,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
+
+destroy@1.2.0, destroy@^1.0.4, destroy@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
+  integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
 detect-node-es@^1.1.0:
   version "1.1.0"
@@ -3146,6 +4027,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==
+
 dlv@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
@@ -3186,6 +4072,33 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
+duplexify@^4.0.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-4.1.3.tgz#a07e1c0d0a2c001158563d32592ba58bddb0236f"
+  integrity sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==
+  dependencies:
+    end-of-stream "^1.4.1"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+    stream-shift "^1.0.2"
+
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
+ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+  integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
+
 electron-to-chromium@^1.5.249:
   version "1.5.252"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.252.tgz#65d8fe59767e68ef90b4b6380cb5c227e6ba860f"
@@ -3211,6 +4124,33 @@ emoji-regex@^9.2.2:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
+emojilib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/emojilib/-/emojilib-2.4.0.tgz#ac518a8bb0d5f76dda57289ccb2fdf9d39ae721e"
+  integrity sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==
+
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
+
+encodeurl@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
+  integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
+
+encodeurl@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
+  integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
+encoding@^0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
+  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+  dependencies:
+    iconv-lite "^0.6.2"
+
 end-of-stream@^1.1.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -3218,10 +4158,32 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
+end-of-stream@^1.4.1:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.5.tgz#7344d711dea40e0b74abc2ed49778743ccedb08c"
+  integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
+  dependencies:
+    once "^1.4.0"
+
 entities@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+env-paths@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
+  integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
+
+environment@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/environment/-/environment-1.1.0.tgz#8e86c66b180f363c7ab311787e0259665f45a9f1"
+  integrity sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==
+
+err-code@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
+  integrity sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -3492,10 +4454,26 @@ escape-goat@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz#1b2dc77003676c457ec760b2dc68edb648188675"
   integrity sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==
 
+escape-html@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escodegen@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.1.0.tgz#ba93bbb7a43986d29d6041f99f5262da773e2e17"
+  integrity sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^5.2.0"
+    esutils "^2.0.2"
+  optionalDependencies:
+    source-map "~0.6.1"
 
 eslint-config-airbnb-base@^14.2.1:
   version "14.2.1"
@@ -3678,7 +4656,7 @@ espree@^6.1.2:
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.1.0"
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -3717,6 +4695,33 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+etag@~1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+  integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
+events-listener@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/events-listener/-/events-listener-1.1.0.tgz#dd49b4628480eba58fde31b870ee346b3990b349"
+  integrity sha512-Kd3EgYfODHueq6GzVfs/VUolh2EgJsS8hkO3KpnDrxVjU3eq63eXM2ujXkhPP+OkeUOhL8CxdfZbQXzryb5C4g==
+
+events-universal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/events-universal/-/events-universal-1.0.1.tgz#b56a84fd611b6610e0a2d0f09f80fdf931e2dfe6"
+  integrity sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==
+  dependencies:
+    bare-events "^2.7.0"
+
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 execa@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.0.tgz#7f37d6ec17f09e6b8fc53288611695b6d12b9daf"
@@ -3745,6 +4750,82 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exegesis-express@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/exegesis-express/-/exegesis-express-4.0.0.tgz#f5f8486f6f0d81739e8e27ce75ce0f61ba3f3578"
+  integrity sha512-V2hqwTtYRj0bj43K4MCtm0caD97YWkqOUHFMRCBW5L1x9IjyqOEc7Xa4oQjjiFbeFOSQzzwPV+BzXsQjSz08fw==
+  dependencies:
+    exegesis "^4.1.0"
+
+exegesis@^4.1.0, exegesis@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/exegesis/-/exegesis-4.3.0.tgz#3b5c45222f543f70ab89fa49eea3a564111a7324"
+  integrity sha512-V90IJQ4XYO1SfH5qdJTOijXkQTF3hSpSHHqlf7MstUMDKP22iAvi63gweFLtPZ4Gj3Wnh8RgJX5TGu0WiwTyDQ==
+  dependencies:
+    "@apidevtools/json-schema-ref-parser" "^9.0.3"
+    ajv "^8.3.0"
+    ajv-formats "^2.1.0"
+    body-parser "^1.18.3"
+    content-type "^1.0.4"
+    deep-freeze "0.0.1"
+    events-listener "^1.1.0"
+    glob "^10.3.10"
+    json-ptr "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    lodash "^4.17.11"
+    openapi3-ts "^3.1.1"
+    promise-breaker "^6.0.0"
+    qs "^6.6.0"
+    raw-body "^2.3.3"
+    semver "^7.0.0"
+
+exponential-backoff@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.3.tgz#51cf92c1c0493c766053f9d3abee4434c244d2f6"
+  integrity sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==
+
+express@^4.16.4:
+  version "4.22.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.22.2.tgz#c17ae0981e5efc24b22272f0e041c4662503b700"
+  integrity sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==
+  dependencies:
+    accepts "~1.3.8"
+    array-flatten "1.1.1"
+    body-parser "~1.20.5"
+    content-disposition "~0.5.4"
+    content-type "~1.0.4"
+    cookie "~0.7.1"
+    cookie-signature "~1.0.6"
+    debug "2.6.9"
+    depd "2.0.0"
+    encodeurl "~2.0.0"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "~1.3.1"
+    fresh "~0.5.2"
+    http-errors "~2.0.0"
+    merge-descriptors "1.0.3"
+    methods "~1.1.2"
+    on-finished "~2.4.1"
+    parseurl "~1.3.3"
+    path-to-regexp "~0.1.12"
+    proxy-addr "~2.0.7"
+    qs "~6.15.1"
+    range-parser "~1.2.1"
+    safe-buffer "5.2.1"
+    send "~0.19.0"
+    serve-static "~1.16.2"
+    setprototypeof "1.2.0"
+    statuses "~2.0.1"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
+
+extend@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 external-editor@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
@@ -3763,6 +4844,11 @@ fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-fifo@^1.2.0, fast-fifo@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
+  integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
 fast-glob@^3.1.1:
   version "3.2.2"
@@ -3797,6 +4883,11 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-uri@^3.0.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.3.tgz#f695a40f006aba505631573a0021ddb21194ad11"
+  integrity sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==
+
 fastq@^1.6.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.6.1.tgz#4570c74f2ded173e71cf0beb08ac70bb85826791"
@@ -3811,10 +4902,30 @@ faye-websocket@0.11.4:
   dependencies:
     websocket-driver ">=0.5.1"
 
+fecha@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
+  integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
+
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 figures@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.1.0.tgz#4b198dd07d8d71530642864af2d45dd9e459c4ec"
   integrity sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+figures@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
 
@@ -3824,6 +4935,11 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
+
+filesize@^6.1.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-6.4.0.tgz#914f50471dd66fdca3cefe628bd0cde4ef769bcd"
+  integrity sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -3839,6 +4955,32 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+finalhandler@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
+  integrity sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    statuses "~1.5.0"
+    unpipe "~1.0.0"
+
+finalhandler@~1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.3.2.tgz#1ebc2228fc7673aac4a472c310cc05b77d852b88"
+  integrity sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~2.0.0"
+    escape-html "~1.0.3"
+    on-finished "~2.4.1"
+    parseurl "~1.3.3"
+    statuses "~2.0.2"
+    unpipe "~1.0.0"
+
 find-up@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -3846,6 +4988,80 @@ find-up@4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+firebase-tools@^13:
+  version "13.35.1"
+  resolved "https://registry.yarnpkg.com/firebase-tools/-/firebase-tools-13.35.1.tgz#fb53464ba970e63ae2c7b63183784ea86e14b914"
+  integrity sha512-QmMy4hnd0Q+V+7GFhZUV80+kG0WC1+UOtuaaQWx+cstt+XepUcpju/KW4cBknnyql521BghfuAhveckQQ1g+HA==
+  dependencies:
+    "@electric-sql/pglite" "^0.2.16"
+    "@google-cloud/cloud-sql-connector" "^1.3.3"
+    "@google-cloud/pubsub" "^4.5.0"
+    abort-controller "^3.0.0"
+    ajv "^8.17.1"
+    ajv-formats "3.0.1"
+    archiver "^7.0.0"
+    async-lock "1.4.1"
+    body-parser "^1.19.0"
+    chokidar "^3.6.0"
+    cjson "^0.3.1"
+    cli-table3 "0.6.5"
+    colorette "^2.0.19"
+    commander "^5.1.0"
+    configstore "^5.0.1"
+    cors "^2.8.5"
+    cross-env "^7.0.3"
+    cross-spawn "^7.0.5"
+    csv-parse "^5.0.4"
+    deep-equal-in-any-order "^2.0.6"
+    exegesis "^4.2.0"
+    exegesis-express "^4.0.0"
+    express "^4.16.4"
+    filesize "^6.1.0"
+    form-data "^4.0.1"
+    fs-extra "^10.1.0"
+    fuzzy "^0.1.3"
+    gaxios "^6.7.0"
+    glob "^10.4.1"
+    google-auth-library "^9.11.0"
+    inquirer "^8.2.6"
+    inquirer-autocomplete-prompt "^2.0.1"
+    js-yaml "^3.14.1"
+    jsonwebtoken "^9.0.0"
+    leven "^3.1.0"
+    libsodium-wrappers "^0.7.10"
+    lodash "^4.17.21"
+    lsofi "1.0.0"
+    marked "^13.0.2"
+    marked-terminal "^7.0.0"
+    mime "^2.5.2"
+    minimatch "^3.0.4"
+    morgan "^1.10.0"
+    node-fetch "^2.6.7"
+    open "^6.3.0"
+    ora "^5.4.1"
+    p-limit "^3.0.1"
+    pg "^8.11.3"
+    portfinder "^1.0.32"
+    progress "^2.0.3"
+    proxy-agent "^6.3.0"
+    retry "^0.13.1"
+    semver "^7.5.2"
+    sql-formatter "^15.3.0"
+    stream-chain "^2.2.4"
+    stream-json "^1.7.3"
+    superstatic "^9.2.0"
+    tar "^6.1.11"
+    tcp-port-used "^1.0.2"
+    tmp "^0.2.3"
+    triple-beam "^1.3.0"
+    universal-analytics "^0.5.3"
+    update-notifier-cjs "^5.1.6"
+    uuid "^8.3.2"
+    winston "^3.0.0"
+    winston-transport "^4.4.0"
+    ws "^7.5.10"
+    yaml "^2.4.1"
 
 firebase@10.14.1:
   version "10.14.1"
@@ -3912,6 +5128,11 @@ fn-name@~2.0.1:
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
   integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
 
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -3926,6 +5147,14 @@ for-each@^0.3.5:
   dependencies:
     is-callable "^1.2.7"
 
+foreground-child@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
+
 form-data@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
@@ -3934,6 +5163,36 @@ form-data@3.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+form-data@^2.5.5:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.6.tgz#ef39b3d99e2fc9f25420c0db7962fe36cafcd244"
+  integrity sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
+    safe-buffer "^5.2.1"
+
+form-data@^4.0.1:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 formik@^2.1.4:
   version "2.1.4"
@@ -3949,7 +5208,17 @@ formik@^2.1.4:
     tiny-warning "^1.0.2"
     tslib "^1.10.0"
 
-fs-extra@^10.0.0:
+forwarded@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
+  integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
+
+fresh@~0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+  integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
+
+fs-extra@^10.0.0, fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
@@ -3957,6 +5226,20 @@ fs-extra@^10.0.0:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
+
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
+fs-minipass@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-3.0.3.tgz#79a85981c4dc120065e96f62086bf6f9dc26cc54"
+  integrity sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==
+  dependencies:
+    minipass "^7.0.3"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -4004,6 +5287,68 @@ functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
+fuzzy@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/fuzzy/-/fuzzy-0.1.3.tgz#4c76ec2ff0ac1a36a9dccf9a00df8623078d4ed8"
+  integrity sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==
+
+gaxios@7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-7.1.3.tgz#c5312f4254abc1b8ab53aef30c22c5229b80b1e1"
+  integrity sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^7.0.1"
+    node-fetch "^3.3.2"
+    rimraf "^5.0.1"
+
+gaxios@^6.0.0, gaxios@^6.1.1, gaxios@^6.7.0:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-6.7.1.tgz#ebd9f7093ede3ba502685e73390248bb5b7f71fb"
+  integrity sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^7.0.1"
+    is-stream "^2.0.0"
+    node-fetch "^2.6.9"
+    uuid "^9.0.1"
+
+gaxios@^7.0.0, gaxios@^7.1.4:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-7.2.0.tgz#d76ef8e3f6e4ff1c8c3066fcb37fa52e8b85d286"
+  integrity sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^7.0.1"
+    node-fetch "^3.3.2"
+
+gcp-metadata@8.1.2:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-8.1.2.tgz#e62e3373ddf41fc727ccc31c55c687b798bee898"
+  integrity sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==
+  dependencies:
+    gaxios "^7.0.0"
+    google-logging-utils "^1.0.0"
+    json-bigint "^1.0.0"
+
+gcp-metadata@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-6.1.1.tgz#f65aa69f546bc56e116061d137d3f5f90bdec494"
+  integrity sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==
+  dependencies:
+    gaxios "^6.1.1"
+    google-logging-utils "^0.0.2"
+    json-bigint "^1.0.0"
+
+gcp-metadata@^8.0.0:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-8.1.3.tgz#60c6744240dbe5fbde30112b9d9aaa25ee611eb1"
+  integrity sha512-ziTrzUhhpL9Zk5k0HHzgP/KIpWDJT0VMBC/ynt/QIBvTW+UUcSivQRl6VlwTf/EilDxtSWklHoRsKy1c4k+59w==
+  dependencies:
+    gaxios "7.1.3"
+    google-logging-utils "1.1.3"
+    json-bigint "^1.0.0"
 
 generator-function@^2.0.0:
   version "2.0.0"
@@ -4095,6 +5440,15 @@ get-symbol-description@^1.1.0:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.6"
 
+get-uri@^6.0.1:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-6.0.5.tgz#714892aa4a871db671abc5395e5e9447bc306a16"
+  integrity sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==
+  dependencies:
+    basic-ftp "^5.0.2"
+    data-uri-to-buffer "^6.0.2"
+    debug "^4.3.4"
+
 git-up@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/git-up/-/git-up-4.0.1.tgz#cb2ef086653640e721d2042fe3104857d89007c0"
@@ -4131,6 +5485,32 @@ glob-parent@^6.0.1:
   dependencies:
     is-glob "^4.0.3"
 
+glob-slash@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/glob-slash/-/glob-slash-1.0.0.tgz#fe52efa433233f74a2fe64c7abb9bc848202ab95"
+  integrity sha512-ZwFh34WZhZX28ntCMAP1mwyAJkn8+Omagvt/GvA+JQM/qgT0+MR2NPF3vhvgdshfdvDyGZXs8fPXW84K32Wjuw==
+
+glob-slasher@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/glob-slasher/-/glob-slasher-1.0.1.tgz#747a0e5bb222642ee10d3e05443e109493cb0f8e"
+  integrity sha512-5MUzqFiycIKLMD1B0dYOE4hGgLLUZUNGGYO4BExdwT32wUwW3DBOE7lMQars7vB1q43Fb3Tyt+HmgLKsJhDYdg==
+  dependencies:
+    glob-slash "^1.0.0"
+    lodash.isobject "^2.4.1"
+    toxic "^1.0.0"
+
+glob@^10.0.0, glob@^10.2.2, glob@^10.3.10, glob@^10.3.7, glob@^10.4.1:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
+
 glob@^7.0.0:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -4161,6 +5541,13 @@ global-dirs@^2.0.1:
   integrity sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==
   dependencies:
     ini "^1.3.5"
+
+global-dirs@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.1.tgz#0c488971f066baceda21447aecb1a8b911d22485"
+  integrity sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==
+  dependencies:
+    ini "2.0.0"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -4193,6 +5580,88 @@ globby@11.0.0:
     ignore "^5.1.4"
     merge2 "^1.3.0"
     slash "^3.0.0"
+
+google-auth-library@10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-10.5.0.tgz#3f0ebd47173496b91d2868f572bb8a8180c4b561"
+  integrity sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==
+  dependencies:
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    gaxios "^7.0.0"
+    gcp-metadata "^8.0.0"
+    google-logging-utils "^1.0.0"
+    gtoken "^8.0.0"
+    jws "^4.0.0"
+
+google-auth-library@^10.0.0:
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-10.9.0.tgz#61e742af957818f572c3a5bce634c68355241d64"
+  integrity sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==
+  dependencies:
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    gaxios "^7.1.4"
+    gcp-metadata "8.1.2"
+    google-logging-utils "1.1.3"
+    jws "^4.0.0"
+
+google-auth-library@^9.11.0, google-auth-library@^9.3.0:
+  version "9.15.1"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-9.15.1.tgz#0c5d84ed1890b2375f1cd74f03ac7b806b392928"
+  integrity sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==
+  dependencies:
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    gaxios "^6.1.1"
+    gcp-metadata "^6.1.0"
+    gtoken "^7.0.0"
+    jws "^4.0.0"
+
+google-gax@^4.3.3:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-4.6.1.tgz#57f8e3d893d4c708a71167cdcf47eb3afab95929"
+  integrity sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==
+  dependencies:
+    "@grpc/grpc-js" "^1.10.9"
+    "@grpc/proto-loader" "^0.7.13"
+    "@types/long" "^4.0.0"
+    abort-controller "^3.0.0"
+    duplexify "^4.0.0"
+    google-auth-library "^9.3.0"
+    node-fetch "^2.7.0"
+    object-hash "^3.0.0"
+    proto3-json-serializer "^2.0.2"
+    protobufjs "^7.3.2"
+    retry-request "^7.0.0"
+    uuid "^9.0.1"
+
+google-logging-utils@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz#17b71f1f95d266d2ddd356b8f00178433f041b17"
+  integrity sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==
+
+google-logging-utils@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-0.0.2.tgz#5fd837e06fa334da450433b9e3e1870c1594466a"
+  integrity sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==
+
+google-logging-utils@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-1.1.4.tgz#279c0f58efda53880e9bf0dda8b6d32789c570f9"
+  integrity sha512-LXxE6ND+JHhDPYtPFt3oeWrjxFPrnRZCZ4At6lpbi1ZDSAN7bmGET9s53vvARbxT93p+xpeDUbc/nCR4C+7vcw==
+
+googleapis-common@^8.0.2-rc.0:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/googleapis-common/-/googleapis-common-8.0.2.tgz#471159a261cd9b7a38fd3ef2f6848dee346dc251"
+  integrity sha512-5MXeQzIZaqCH7B+HJWqhQm946VARpZep6acbWSr/fcgF2cQANq7allgX+i/G0EqF0WyUxB277gtWMzRYHMl9tg==
+  dependencies:
+    extend "^3.0.2"
+    gaxios "7.1.3"
+    google-auth-library "10.5.0"
+    google-logging-utils "1.1.3"
+    qs "^6.7.0"
+    url-template "^2.0.8"
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -4244,10 +5713,31 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@4.2.10:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.6:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+gtoken@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-7.1.0.tgz#d61b4ebd10132222817f7222b1e6064bd463fc26"
+  integrity sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==
+  dependencies:
+    gaxios "^6.0.0"
+    jws "^4.0.0"
+
+gtoken@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-8.0.0.tgz#d67a0e346dd441bfb54ad14040ddc3b632886575"
+  integrity sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==
+  dependencies:
+    gaxios "^7.0.0"
+    jws "^4.0.0"
 
 gud@^1.0.0:
   version "1.0.0"
@@ -4327,10 +5817,27 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
+  dependencies:
+    function-bind "^1.1.2"
+
+heap-js@^2.2.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/heap-js/-/heap-js-2.7.1.tgz#3f152279e42214725cac405257554b000b178cc4"
+  integrity sha512-EQfezRg0NCZGNlhlDR3Evrw1FVL2G3LhU7EgPoxufQKruNBSYA8MiRPHeWbU+36o+Fhel0wMwM+sLEiBAlNLJA==
+
 hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
+
+highlight.js@^10.7.1:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
+  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
 history@^4.9.0:
   version "4.10.1"
@@ -4379,22 +5886,85 @@ http-cache-semantics@^4.0.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
+http-cache-semantics@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz#205f4db64f8562b76a4ff9235aa5279839a09dd5"
+  integrity sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==
+
+http-errors@~2.0.0, http-errors@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
+  integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
+  dependencies:
+    depd "~2.0.0"
+    inherits "~2.0.4"
+    setprototypeof "~1.2.0"
+    statuses "~2.0.2"
+    toidentifier "~1.0.1"
+
 "http-parser-js@>=0.4.0 <0.4.11":
   version "0.4.10"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.10.tgz#92c9c1374c35085f75db359ec56cc257cbb93fa4"
   integrity sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=
+
+http-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
+  integrity sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==
+  dependencies:
+    "@tootallnate/once" "2"
+    agent-base "6"
+    debug "4"
+
+http-proxy-agent@^7.0.0, http-proxy-agent@^7.0.1:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
+https-proxy-agent@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
+https-proxy-agent@^7.0.1, https-proxy-agent@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
 
 human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-iconv-lite@^0.4.24:
+iconv-lite@^0.4.24, iconv-lite@~0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@^0.6.2:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
+iconv-lite@^0.7.0:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.3.tgz#84ee12f963e7de50bc01a13e160a078b3b0f415f"
+  integrity sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 idb@7.1.1:
   version "7.1.1"
@@ -4405,6 +5975,11 @@ idb@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/idb/-/idb-8.0.0.tgz#33d7ed894ed36e23bcb542fb701ad579bfaad41f"
   integrity sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw==
+
+ieee754@^1.1.13, ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -4469,15 +6044,36 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3:
+inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
+
+ini@^1.3.4:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+inquirer-autocomplete-prompt@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-2.0.1.tgz#72868aada4d9d36814a6054cbd1ececc63aab0c6"
+  integrity sha512-jUHrH0btO7j5r8DTQgANf2CBkTZChoVySD8zF/wp5fZCOLIuUbleXhf4ZY5jNBOc1owA3gdfWtfZuppfYBhcUg==
+  dependencies:
+    ansi-escapes "^4.3.2"
+    figures "^3.2.0"
+    picocolors "^1.0.0"
+    run-async "^2.4.1"
+    rxjs "^7.5.4"
 
 inquirer@7.0.6:
   version "7.0.6"
@@ -4516,6 +6112,32 @@ inquirer@^7.0.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
+
+inquirer@^8.2.6:
+  version "8.2.7"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.7.tgz#62f6b931a9b7f8735dc42db927316d8fb6f71de8"
+  integrity sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==
+  dependencies:
+    "@inquirer/external-editor" "^1.0.0"
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.5.5"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+    wrap-ansi "^6.0.1"
+
+install-artifact-from-github@^1.3.5:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/install-artifact-from-github/-/install-artifact-from-github-1.7.0.tgz#986a8c404dc67bf62315517c993322a31f25ad4a"
+  integrity sha512-qAb91yAKVF9rFY4rVP21ZtYUyCScxAFt9udwzVWNLBE1pQcdQeB2gd1HlNPcQNYCzCDvJ/QJQPuWQ6aTmSlU8g==
 
 internal-slot@^1.0.7:
   version "1.0.7"
@@ -4559,6 +6181,21 @@ intl-messageformat@^7.8.4:
   dependencies:
     intl-format-cache "^4.2.21"
     intl-messageformat-parser "^3.6.4"
+
+ip-address@^10.1.1:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
+  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
+
+ip-regex@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+  integrity sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==
+
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-accessor-descriptor@^1.0.0:
   version "1.0.0"
@@ -4789,10 +6426,23 @@ is-installed-globally@^0.3.1:
     global-dirs "^2.0.1"
     is-path-inside "^3.0.1"
 
+is-installed-globally@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
+  integrity sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==
+  dependencies:
+    global-dirs "^3.0.0"
+    is-path-inside "^3.0.2"
+
 is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
+is-lambda@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
+  integrity sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==
 
 is-map@^2.0.3:
   version "2.0.3"
@@ -4809,6 +6459,11 @@ is-npm@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-4.0.0.tgz#c90dd8380696df87a7a6d823c20d0b12bbe3c84d"
   integrity sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==
 
+is-npm@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-5.0.0.tgz#43e8d65cc56e1b67f8d47262cf667099193f45a8"
+  integrity sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==
+
 is-number-object@^1.0.4:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.7.tgz#59d50ada4c45251784e9904f5246c742f07a42fc"
@@ -4823,6 +6478,13 @@ is-number-object@^1.1.1:
   dependencies:
     call-bound "^1.0.3"
     has-tostringtag "^1.0.2"
+
+is-number@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
+  integrity sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==
+  dependencies:
+    kind-of "^3.0.2"
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -4846,6 +6508,11 @@ is-path-inside@^3.0.1:
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
   integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
 
+is-path-inside@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
 is-plain-object@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-3.0.0.tgz#47bfc5da1b5d50d64110806c199359482e75a928"
@@ -4857,6 +6524,11 @@ is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
+
+is-promise@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
+  integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
 is-regex@^1.0.4:
   version "1.0.5"
@@ -4914,6 +6586,11 @@ is-ssh@^1.3.0:
   dependencies:
     protocols "^1.1.0"
 
+is-stream-ended@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-stream-ended/-/is-stream-ended-0.1.4.tgz#f50224e95e06bce0e356d440a4827cd35b267eda"
+  integrity sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -4923,6 +6600,11 @@ is-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+
+is-stream@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
 is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
@@ -4974,6 +6656,16 @@ is-typedarray@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-url@^1.2.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
+
 is-weakmap@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.2.tgz#bf72615d649dfe5f699079c54b83e47d1ae19cfd"
@@ -5001,10 +6693,24 @@ is-weakset@^2.0.3:
     call-bind "^1.0.7"
     get-intrinsic "^1.2.4"
 
+is-wsl@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
+  integrity sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==
+
 is-yarn-global@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232"
   integrity sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
+
+is2@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is2/-/is2-2.0.1.tgz#8ac355644840921ce435d94f05d3a94634d3481a"
+  integrity sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==
+  dependencies:
+    deep-is "^0.1.3"
+    ip-regex "^2.1.0"
+    is-url "^1.2.2"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -5016,15 +6722,33 @@ isarray@^2.0.5:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
   integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+isexe@^3.1.1:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.5.tgz#42e368f68d5e10dadfee4fda7b550bc2d8892dc9"
+  integrity sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==
+
 isobject@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
+
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
 
 iterator.prototype@^1.1.4:
   version "1.1.5"
@@ -5037,6 +6761,15 @@ iterator.prototype@^1.1.4:
     get-proto "^1.0.0"
     has-symbols "^1.1.0"
     set-function-name "^2.0.2"
+
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
 
 jest-diff@^24.0.0, jest-diff@^24.9.0:
   version "24.9.0"
@@ -5063,6 +6796,20 @@ jest-matcher-utils@^24.0.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
+jju@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
+  integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
+
+join-path@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/join-path/-/join-path-1.1.1.tgz#10535a126d24cbd65f7ffcdf15ef2e631076b505"
+  integrity sha512-jnt9OC34sLXMLJ6YfPQ2ZEKrR9mB5ZbSnQb4LPaOx1c5rTzxpR33L18jjp0r75mGGTJmsil3qwN1B5IBeTnSSA==
+  dependencies:
+    as-array "^2.0.0"
+    url-join "0.0.1"
+    valid-url "^1"
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5076,10 +6823,32 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.14.1:
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+  dependencies:
+    argparse "^2.0.1"
+
 jsesc@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
+
+json-bigint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
+  integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
+  dependencies:
+    bignumber.js "^9.0.0"
 
 json-buffer@3.0.0:
   version "3.0.0"
@@ -5096,10 +6865,27 @@ json-parse-better-errors@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
+json-parse-helpfulerror@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz#13f14ce02eed4e981297b64eb9e3b932e2dd13dc"
+  integrity sha512-XgP0FGR77+QhUxjXkwOMkC94k3WtqEBfcnjWqhRd82qTat4SWKRE+9kUnynz/shm3I4ea2+qISvTIeGTNU7kJg==
+  dependencies:
+    jju "^1.1.0"
+
+json-ptr@^3.0.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/json-ptr/-/json-ptr-3.1.1.tgz#184c3d48db659fa9bbc1519f7db6f390ddffb659"
+  integrity sha512-SiSJQ805W1sDUCD1+/t1/1BIrveq2Fe9HJqENxZmMCILmrPI7WhS/pePpIOx85v6/H2z1Vy7AI08GV2TzfXocg==
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -5127,6 +6913,22 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonwebtoken@^9.0.0:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz#6cd57ab01e9b0ac07cb847d53d3c9b6ee31f7ae2"
+  integrity sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==
+  dependencies:
+    jws "^4.0.1"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^7.5.4"
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.5:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz#4766bd05a8e2a11af222becd19e15575e52a853a"
@@ -5136,6 +6938,23 @@ jsonfile@^6.0.1:
     array.prototype.flat "^1.3.1"
     object.assign "^4.1.4"
     object.values "^1.1.6"
+
+jwa@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-2.0.1.tgz#bf8176d1ad0cd72e0f3f58338595a13e110bc804"
+  integrity sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==
+  dependencies:
+    buffer-equal-constant-time "^1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^4.0.0, jws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-4.0.1.tgz#07edc1be8fac20e677b283ece261498bd38f0690"
+  integrity sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==
+  dependencies:
+    jwa "^2.0.1"
+    safe-buffer "^5.0.1"
 
 keyv@^3.0.0:
   version "3.1.0"
@@ -5163,6 +6982,11 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
+
 language-subtag-registry@^0.3.20:
   version "0.3.23"
   resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz#23529e04d9e3b74679d70142df3fd2eb6ec572e7"
@@ -5182,6 +7006,18 @@ latest-version@^5.0.0:
   dependencies:
     package-json "^6.3.0"
 
+lazystream@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.1.tgz#494c831062f1f9408251ec44db1cba29242a2638"
+  integrity sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==
+  dependencies:
+    readable-stream "^2.0.5"
+
+leven@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
+  integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -5189,6 +7025,18 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+libsodium-wrappers@^0.7.10:
+  version "0.7.16"
+  resolved "https://registry.yarnpkg.com/libsodium-wrappers/-/libsodium-wrappers-0.7.16.tgz#abaa065e914562695c6c1d66527c8e72bbbaec15"
+  integrity sha512-Gtr/WBx4dKjvRL1pvfwZqu7gO6AfrQ0u9vFL+kXihtHf6NfkROR8pjYWn98MFDI3jN19Ii1ZUfPR9afGiPyfHg==
+  dependencies:
+    libsodium "^0.7.16"
+
+libsodium@^0.7.16:
+  version "0.7.16"
+  resolved "https://registry.yarnpkg.com/libsodium/-/libsodium-0.7.16.tgz#3d4f9d68ed887bb8bf2e76bb3ba231265eae58a0"
+  integrity sha512-3HrzSPuzm6Yt9aTYCDxYEG8x8/6C0+ag655Y7rhhWZM9PT4NpdnbqlzXhGZlDnkgR6MeSTnOt/VIyHLs9aSf+Q==
 
 lilconfig@^2.0.5:
   version "2.1.0"
@@ -5224,6 +7072,11 @@ lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
+lodash._objecttypes@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz#7c0b7f69d98a1f76529f890b0cdb1b4dfec11c11"
+  integrity sha512-XpqGh1e7hhkOzftBfWE7zt+Yn9mVHFkDhicVttvKLsoCMLVVL+xTQjfjB4X4vtznauxv0QZ5ZAeqjvat0dh62Q==
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -5233,6 +7086,53 @@ lodash.find@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
   integrity sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=
+
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
+lodash.isobject@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-2.4.1.tgz#5a2e47fe69953f1ee631a7eba1fe64d2d06558f5"
+  integrity sha512-sTebg2a1PoicYEZXD5PBdQcTlIJ6hUslrlWr7iV0O7n+i4596s2NQ9I5CaZ5FbXSfya/9WQsrYLANUJv9paYVA==
+  dependencies:
+    lodash._objecttypes "~2.4.1"
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
+
+lodash.snakecase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
+  integrity sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==
 
 lodash.throttle@^4.1.1:
   version "4.1.1"
@@ -5248,6 +7148,11 @@ lodash@4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.10:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.19"
@@ -5266,10 +7171,35 @@ log-symbols@^3.0.0:
   dependencies:
     chalk "^2.4.2"
 
+log-symbols@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+  dependencies:
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
+
+logform@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.7.0.tgz#cfca97528ef290f2e125a08396805002b2d060d1"
+  integrity sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==
+  dependencies:
+    "@colors/colors" "1.6.0"
+    "@types/triple-beam" "^1.3.2"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    safe-stable-stringify "^2.3.1"
+    triple-beam "^1.3.0"
+
 long@^5.0.0:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
   integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
+
+long@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
@@ -5288,12 +7218,30 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
+lru-cache@^10.0.1, lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@^7.14.1:
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
+  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
+
+lsofi@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lsofi/-/lsofi-1.0.0.tgz#ed65a9d1d811b835b8c51b61762cefa64eb96a8d"
+  integrity sha512-MKr9vM1MSm+TSKfI05IYxpKV1NCxpJaBLnELyIf784zYJ5KV9lGCE1EvpA2DtXDNM3fCuFeCwXUzim/fyQRi+A==
+  dependencies:
+    is-number "^2.1.0"
+    through2 "^2.0.1"
 
 macos-release@^2.2.0:
   version "2.3.0"
@@ -5307,6 +7255,24 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
+make-fetch-happen@^13.0.0:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz#273ba2f78f45e1f3a6dca91cede87d9fa4821e36"
+  integrity sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==
+  dependencies:
+    "@npmcli/agent" "^2.0.0"
+    cacache "^18.0.0"
+    http-cache-semantics "^4.1.1"
+    is-lambda "^1.0.1"
+    minipass "^7.0.2"
+    minipass-fetch "^3.0.0"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    negotiator "^0.6.3"
+    proc-log "^4.2.0"
+    promise-retry "^2.0.1"
+    ssri "^10.0.0"
+
 markdown-it@^14.0.0:
   version "14.1.0"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.1.0.tgz#3c3c5992883c633db4714ccb4d7b5935d98b7d45"
@@ -5318,6 +7284,24 @@ markdown-it@^14.0.0:
     mdurl "^2.0.0"
     punycode.js "^2.3.1"
     uc.micro "^2.1.0"
+
+marked-terminal@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/marked-terminal/-/marked-terminal-7.3.0.tgz#7a86236565f3dd530f465ffce9c3f8b62ef270e8"
+  integrity sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==
+  dependencies:
+    ansi-escapes "^7.0.0"
+    ansi-regex "^6.1.0"
+    chalk "^5.4.1"
+    cli-highlight "^2.1.11"
+    cli-table3 "^0.6.5"
+    node-emoji "^2.2.0"
+    supports-hyperlinks "^3.1.0"
+
+marked@^13.0.2:
+  version "13.0.3"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-13.0.3.tgz#5c5b4a5d0198060c7c9bc6ef9420a7fed30f822d"
+  integrity sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==
 
 marked@^4.0.0:
   version "4.3.0"
@@ -5334,6 +7318,16 @@ mdurl@^2.0.0:
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
   integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
 
+media-typer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+  integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
+
+merge-descriptors@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.3.tgz#d80319a65f3c7935351e5cfdac8f9318504dbed5"
+  integrity sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -5343,6 +7337,11 @@ merge2@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
+
+methods@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+  integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
 micromatch@^4.0.2:
   version "4.0.2"
@@ -5365,12 +7364,39 @@ mime-db@1.43.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
   integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+"mime-db@>= 1.43.0 < 2":
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
+
 mime-types@2.1.26, mime-types@^2.1.12:
   version "2.1.26"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
   integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
   dependencies:
     mime-db "1.43.0"
+
+mime-types@^2.1.35, mime-types@~2.1.24, mime-types@~2.1.34:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
+mime@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
+mime@^2.5.2:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -5408,6 +7434,27 @@ minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^5.1.0:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.9.tgz#1293ef15db0098b394540e8f9f744f9fda8dee4b"
+  integrity sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^6.1.6:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-6.2.3.tgz#f5c78246aa2c546afa4c7e19294e41e5e9b8f023"
+  integrity sha512-5rvZbDy5y2k40rre/0OBbYnl03en25XPU3gOVO7532beGMjAipq88VdS9OeLOZNrD+Tb0lDhBJHZ7Gcd8qKlPg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^9.0.4:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
+
 minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
@@ -5418,6 +7465,70 @@ minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+minipass-collect@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-2.0.1.tgz#1621bc77e12258a12c60d34e2276ec5c20680863"
+  integrity sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==
+  dependencies:
+    minipass "^7.0.3"
+
+minipass-fetch@^3.0.0:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-3.0.5.tgz#f0f97e40580affc4a35cc4a1349f05ae36cb1e4c"
+  integrity sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==
+  dependencies:
+    minipass "^7.0.3"
+    minipass-sized "^1.0.3"
+    minizlib "^2.1.2"
+  optionalDependencies:
+    encoding "^0.1.13"
+
+minipass-flush@^1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.7.tgz#145c383d5ae294b36030aa80d4e872d08bebcb73"
+  integrity sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-pipeline@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz#68472f79711c084657c067c5c6ad93cddea8214c"
+  integrity sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-sized@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/minipass-sized/-/minipass-sized-1.0.3.tgz#70ee5a7c5052070afacfbc22977ea79def353b70"
+  integrity sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass@^3.0.0:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.6.tgz#7bba384db3a1520d18c9c0e5251c3444e95dd94a"
+  integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
+  dependencies:
+    yallist "^4.0.0"
+
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.2, minipass@^7.0.3, minipass@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+minizlib@^2.1.1, minizlib@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
 mkdirp@^0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
@@ -5425,17 +7536,43 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.6"
 
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 modern-normalize@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/modern-normalize/-/modern-normalize-1.1.0.tgz#da8e80140d9221426bd4f725c6e11283d34f90b7"
   integrity sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==
 
-ms@^2.1.1:
+moo@^0.5.0:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.3.tgz#dfcdb40ff6f1a03c34af5df7f9717cecfa88c38c"
+  integrity sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==
+
+morgan@^1.10.0, morgan@^1.8.2:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.11.0.tgz#98464b8538802f14e9e5374ebe23ac364cd617e8"
+  integrity sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==
+  dependencies:
+    basic-auth "~2.0.1"
+    debug "2.6.9"
+    depd "~2.0.0"
+    on-finished "~2.4.1"
+    on-headers "~1.1.0"
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
+
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.1.3:
+ms@2.1.3, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -5444,6 +7581,20 @@ mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+mz@^2.4.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
+
+nan@^2.20.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.28.0.tgz#126717fd359d5a03d3edf7c44e6ce9b707fb57f5"
+  integrity sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==
 
 nanoid@^3.3.11:
   version "3.3.11"
@@ -5465,10 +7616,40 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+nearley@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.20.1.tgz#246cd33eff0d012faf197ff6774d7ac78acdd474"
+  integrity sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
+
+negotiator@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
+
+negotiator@^0.6.3, negotiator@~0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.4.tgz#777948e2452651c570b712dd01c23e262713fff7"
+  integrity sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==
+
+netmask@^2.0.2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.1.1.tgz#80043d265b53aa521b3bd01e8fcdf353f9e1e81e"
+  integrity sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
 node-emoji@^1.11.0:
   version "1.11.0"
@@ -5477,10 +7658,52 @@ node-emoji@^1.11.0:
   dependencies:
     lodash "^4.17.21"
 
+node-emoji@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-2.2.0.tgz#1d000e3c76e462577895be1b436f4aa2d6760eb0"
+  integrity sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==
+  dependencies:
+    "@sindresorhus/is" "^4.6.0"
+    char-regex "^1.0.2"
+    emojilib "^2.4.0"
+    skin-tone "^2.0.0"
+
 node-fetch@^2.3.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
+node-fetch@^2.6.1, node-fetch@^2.6.7, node-fetch@^2.6.9, node-fetch@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
+
+node-gyp@^10.2.0:
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-10.3.1.tgz#1dd1a1a1c6c5c59da1a76aea06a062786b2c8a1a"
+  integrity sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==
+  dependencies:
+    env-paths "^2.2.0"
+    exponential-backoff "^3.1.1"
+    glob "^10.3.10"
+    graceful-fs "^4.2.6"
+    make-fetch-happen "^13.0.0"
+    nopt "^7.0.0"
+    proc-log "^4.1.0"
+    semver "^7.3.5"
+    tar "^6.2.1"
+    which "^4.0.0"
 
 node-releases@^2.0.19:
   version "2.0.19"
@@ -5491,6 +7714,13 @@ node-releases@^2.0.27:
   version "2.0.27"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
+
+nopt@^7.0.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.1.tgz#1cac0eab9b8e97c9093338446eddd40b2c8ca1e7"
+  integrity sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==
+  dependencies:
+    abbrev "^2.0.0"
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -5531,7 +7761,7 @@ num2fraction@^1.2.2:
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
   integrity sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==
 
-object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -5540,6 +7770,11 @@ object-hash@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
   integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
+
+object-hash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
+  integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
 
 object-inspect@^1.13.1:
   version "1.13.2"
@@ -5631,6 +7866,25 @@ object.values@^1.2.1:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
+on-finished@^2.2.0, on-finished@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
+  integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
+  dependencies:
+    ee-first "1.1.1"
+
+on-finished@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
+  integrity sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==
+  dependencies:
+    ee-first "1.1.1"
+
+on-headers@^1.0.0, on-headers@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.1.0.tgz#59da4f91c45f5f989c6e4bcedc5a3b0aed70ff65"
+  integrity sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==
+
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -5638,12 +7892,33 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
+
 onetime@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
   integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
   dependencies:
     mimic-fn "^2.1.0"
+
+open@^6.3.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-6.4.0.tgz#5c13e96d0dc894686164f18965ecfe889ecfc8a9"
+  integrity sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==
+  dependencies:
+    is-wsl "^1.1.0"
+
+openapi3-ts@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/openapi3-ts/-/openapi3-ts-3.2.0.tgz#7e30d33c480e938e67e809ab16f419bc9beae3f8"
+  integrity sha512-/ykNWRV5Qs0Nwq7Pc0nJ78fgILvOT/60OxEmB3v7yQ8a8Bwcm43D4diaYazG/KBn6czA+52XYy931WFLMCUeSg==
+  dependencies:
+    yaml "^2.2.1"
 
 optionator@^0.8.3:
   version "0.8.3"
@@ -5668,6 +7943,21 @@ ora@4.0.3:
     is-interactive "^1.0.0"
     log-symbols "^3.0.0"
     mute-stream "0.0.8"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
+
+ora@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
+  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
+  dependencies:
+    bl "^4.1.0"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    is-unicode-supported "^0.1.0"
+    log-symbols "^4.1.0"
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
@@ -5703,6 +7993,11 @@ p-cancelable@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.0.0.tgz#4a3740f5bdaf5ed5d7c3e34882c6fb5d6b266a6e"
   integrity sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==
 
+p-defer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-3.0.0.tgz#d1dceb4ee9b2b604b1d94ffec83760175d4e6f83"
+  integrity sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==
+
 p-event@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/p-event/-/p-event-4.1.0.tgz#e92bb866d7e8e5b732293b1c8269d38e9982bf8e"
@@ -5722,12 +8017,31 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
 p-locate@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-map@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
+  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
+  dependencies:
+    aggregate-error "^3.0.0"
+
+p-throttle@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/p-throttle/-/p-throttle-7.0.0.tgz#d2650e884dad46fd626a9a5cfc3fb239cb799dee"
+  integrity sha512-aio0v+S0QVkH1O+9x4dHtD4dgCExACcL+3EtNaGqC01GBudS9ijMuUsmN8OVScyV4OOp0jqdLShZFuSlbL/AsA==
 
 p-timeout@^2.0.1:
   version "2.0.1"
@@ -5740,6 +8054,33 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+pac-proxy-agent@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz#9cfaf33ff25da36f6147a20844230ec92c06e5df"
+  integrity sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==
+  dependencies:
+    "@tootallnate/quickjs-emscripten" "^0.23.0"
+    agent-base "^7.1.2"
+    debug "^4.3.4"
+    get-uri "^6.0.1"
+    http-proxy-agent "^7.0.0"
+    https-proxy-agent "^7.0.6"
+    pac-resolver "^7.0.1"
+    socks-proxy-agent "^8.0.5"
+
+pac-resolver@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-7.0.1.tgz#54675558ea368b64d210fd9c92a640b5f3b8abb6"
+  integrity sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==
+  dependencies:
+    degenerator "^5.0.0"
+    netmask "^2.0.2"
+
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
 package-json@^6.3.0:
   version "6.5.0"
@@ -5802,6 +8143,28 @@ parse-url@^5.0.0:
     parse-path "^4.0.0"
     protocols "^1.4.0"
 
+parse5-htmlparser2-tree-adapter@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
+  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
+  dependencies:
+    parse5 "^6.0.1"
+
+parse5@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
+  integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
+
+parse5@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
+
+parseurl@^1.3.3, parseurl@~1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -5827,12 +8190,37 @@ path-parse@^1.0.6, path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
 path-to-regexp@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
   integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
   dependencies:
     isarray "0.0.1"
+
+path-to-regexp@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.9.0.tgz#5dc0753acbf8521ca2e0f137b4578b917b10cf24"
+  integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
+  dependencies:
+    isarray "0.0.1"
+
+path-to-regexp@^8.0.0:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz#795c420c4f7ca45c5b887366f622ee0c9852cccd"
+  integrity sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==
+
+path-to-regexp@~0.1.12:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.13.tgz#9b22ec16bc3ab88d05a0c7e369869421401ab17d"
+  integrity sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -5843,6 +8231,62 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+pg-cloudflare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz#4b4c20e6d8ae531d400730f4804571a8d62f1497"
+  integrity sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==
+
+pg-connection-string@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.14.0.tgz#abc26ee4f37c56c0f3ae0fcf0b0653cc4e1c0fd9"
+  integrity sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.14.0.tgz#f35ae4eb846780cad71af24099b3edfa9781ad90"
+  integrity sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==
+
+pg-protocol@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.15.0.tgz#758f6c0679cc0bbf4938603b7597703f333180c0"
+  integrity sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==
+
+pg-types@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+pg@^8.11.3:
+  version "8.22.0"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.22.0.tgz#55ca3975026180c6dced6eec3a20a844c2dc9237"
+  integrity sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==
+  dependencies:
+    pg-connection-string "^2.14.0"
+    pg-pool "^3.14.0"
+    pg-protocol "^1.15.0"
+    pg-types "2.2.0"
+    pgpass "1.0.5"
+  optionalDependencies:
+    pg-cloudflare "^1.4.0"
+
+pgpass@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.5.tgz#9b873e4a564bb10fa7a7dbd55312728d422a223d"
+  integrity sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==
+  dependencies:
+    split2 "^4.1.0"
 
 picocolors@^0.2.1:
   version "0.2.1"
@@ -5873,6 +8317,14 @@ popper.js@^1.14.4:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
+
+portfinder@^1.0.32:
+  version "1.0.38"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.38.tgz#e4fb3a2d888b20d2977da050e48ab5e1f57a185e"
+  integrity sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==
+  dependencies:
+    async "^3.2.6"
+    debug "^4.3.6"
 
 possible-typed-array-names@^1.0.0:
   version "1.0.0"
@@ -5966,6 +8418,28 @@ postcss@^8.4.49:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.1.tgz#c40b3da0222c500ff1e51c5d7014b60b79697c7a"
+  integrity sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -5996,10 +8470,38 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==
 
-progress@^2.0.0:
+proc-log@^4.1.0, proc-log@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-4.2.0.tgz#b6f461e4026e75fdfe228b265e9f7a00779d7034"
+  integrity sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==
+
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
+progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+promise-breaker@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/promise-breaker/-/promise-breaker-6.0.0.tgz#107d2b70f161236abdb4ac5a736c7eb8df489d0f"
+  integrity sha512-BthzO9yTPswGf7etOBiHCVuugs2N01/Q/94dIPls48z2zCmrnDptUUZzfIb+41xq0MnYZ/BzmOd6ikDR4ibNZA==
+
+promise-retry@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-2.0.1.tgz#ff747a13620ab57ba688f5fc67855410c370da22"
+  integrity sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==
+  dependencies:
+    err-code "^2.0.2"
+    retry "^0.12.0"
 
 promise@^8.0.3:
   version "8.0.3"
@@ -6031,6 +8533,18 @@ property-expr@^1.5.0:
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.5.1.tgz#22e8706894a0c8e28d58735804f6ba3a3673314f"
   integrity sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==
 
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
+  integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
+
+proto3-json-serializer@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz#5b705203b4d58f3880596c95fad64902617529dd"
+  integrity sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==
+  dependencies:
+    protobufjs "^7.2.5"
+
 protobufjs@^7.2.5:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.4.0.tgz#7efe324ce9b3b61c82aae5de810d287bc08a248a"
@@ -6049,10 +8563,54 @@ protobufjs@^7.2.5:
     "@types/node" ">=13.7.0"
     long "^5.0.0"
 
+protobufjs@^7.3.2, protobufjs@^7.5.5:
+  version "7.6.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.5.tgz#7b9250cdaf4a06139a9f0fe468a40d7d4febca71"
+  integrity sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.5"
+    "@protobufjs/eventemitter" "^1.1.1"
+    "@protobufjs/fetch" "^1.1.1"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.1"
+    "@types/node" ">=13.7.0"
+    long "^5.3.2"
+
 protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.7.tgz#95f788a4f0e979b291ffefcf5636ad113d037d32"
   integrity sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==
+
+proxy-addr@~2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
+  integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
+  dependencies:
+    forwarded "0.2.0"
+    ipaddr.js "1.9.1"
+
+proxy-agent@^6.3.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-6.5.0.tgz#9e49acba8e4ee234aacb539f89ed9c23d02f232d"
+  integrity sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "^4.3.4"
+    http-proxy-agent "^7.0.1"
+    https-proxy-agent "^7.0.6"
+    lru-cache "^7.14.1"
+    pac-proxy-agent "^7.1.0"
+    proxy-from-env "^1.1.0"
+    socks-proxy-agent "^8.0.5"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pump@^3.0.0:
   version "3.0.0"
@@ -6079,6 +8637,13 @@ pupa@^2.0.1:
   dependencies:
     escape-goat "^2.0.0"
 
+pupa@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.1.1.tgz#f5e8fd4afc2c5d97828faa523549ed8744a20d62"
+  integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
+  dependencies:
+    escape-goat "^2.0.0"
+
 purgecss@^4.0.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/purgecss/-/purgecss-4.1.3.tgz#683f6a133c8c4de7aa82fe2746d1393b214918f7"
@@ -6088,6 +8653,14 @@ purgecss@^4.0.3:
     glob "^7.1.7"
     postcss "^8.3.5"
     postcss-selector-parser "^6.0.6"
+
+qs@^6.6.0, qs@^6.7.0, qs@~6.15.1:
+  version "6.15.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.3.tgz#76852132a58ed5c7c0ef67e4441b9bb5d6061b3b"
+  integrity sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==
+  dependencies:
+    es-define-property "^1.0.1"
+    side-channel "^1.1.1"
 
 quick-lru@^5.1.1:
   version "5.1.1"
@@ -6101,6 +8674,34 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
+
+range-parser@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
+raw-body@^2.3.3, raw-body@~2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.3.tgz#11c6650ee770a7de1b494f197927de0c923822e2"
+  integrity sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==
+  dependencies:
+    bytes "~3.1.2"
+    http-errors "~2.0.1"
+    iconv-lite "~0.4.24"
+    unpipe "~1.0.0"
+
 rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -6110,6 +8711,15 @@ rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+re2@1.21.4, re2@^1.17.7:
+  version "1.21.4"
+  resolved "https://registry.yarnpkg.com/re2/-/re2-1.21.4.tgz#d688edcc40da3cf542ee3a480a8b60e5900dd24d"
+  integrity sha512-MVIfXWJmsP28mRsSt8HeL750ifb8H5+oF2UDIxGaiJCr8fkMqhLZ7kcX9ADRk2dC8qeGKedB7UVYRfBVpEiLfA==
+  dependencies:
+    install-artifact-from-github "^1.3.5"
+    nan "^2.20.0"
+    node-gyp "^10.2.0"
 
 react-app-polyfill@^1.0.6:
   version "1.0.6"
@@ -6266,6 +8876,46 @@ react@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
 
+readable-stream@^2.0.5, readable-stream@~2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+readable-stream@^4.0.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.7.0.tgz#cedbd8a1146c13dfff8dab14068028d58c15ac91"
+  integrity sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==
+  dependencies:
+    abort-controller "^3.0.0"
+    buffer "^6.0.3"
+    events "^3.3.0"
+    process "^0.11.10"
+    string_decoder "^1.3.0"
+
+readdir-glob@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/readdir-glob/-/readdir-glob-1.1.3.tgz#c3d831f51f5e7bfa62fa2ffbe4b508c640f09584"
+  integrity sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==
+  dependencies:
+    minimatch "^5.1.0"
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -6374,7 +9024,14 @@ registry-auth-token@^4.0.0:
   dependencies:
     rc "^1.2.8"
 
-registry-url@^5.0.0:
+registry-auth-token@^5.0.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-5.1.1.tgz#f1ff69c8e492e7edee07110b4752dd0a8aa82853"
+  integrity sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==
+  dependencies:
+    "@pnpm/npm-conf" "^3.0.2"
+
+registry-url@^5.0.0, registry-url@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-5.1.0.tgz#e98334b50d5434b81136b44ec638d9c2009c5009"
   integrity sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==
@@ -6422,6 +9079,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -6499,10 +9161,29 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
-retry@0.12.0:
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+retry-request@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/retry-request/-/retry-request-7.0.2.tgz#60bf48cfb424ec01b03fca6665dee91d06dd95f3"
+  integrity sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==
+  dependencies:
+    "@types/request" "^2.48.8"
+    extend "^3.0.2"
+    teeny-request "^9.0.0"
+
+retry@0.12.0, retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
-  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
+  integrity sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==
+
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
   version "1.0.4"
@@ -6525,6 +9206,13 @@ rimraf@2.6.3:
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
+
+rimraf@^5.0.1:
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.10.tgz#23b9843d3dc92db71f96e1a2ce92e39fd2a8221c"
+  integrity sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==
+  dependencies:
+    glob "^10.3.7"
 
 rollup@^4.23.0:
   version "4.31.0"
@@ -6554,12 +9242,28 @@ rollup@^4.23.0:
     "@rollup/rollup-win32-x64-msvc" "4.31.0"
     fsevents "~2.3.2"
 
+router@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/router/-/router-2.2.0.tgz#019be620b711c87641167cc79b99090f00b146ef"
+  integrity sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==
+  dependencies:
+    debug "^4.4.0"
+    depd "^2.0.0"
+    is-promise "^4.0.0"
+    parseurl "^1.3.3"
+    path-to-regexp "^8.0.0"
+
 run-async@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.0.tgz#e59054a5b86876cfae07f431d18cbaddc594f1e8"
   integrity sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==
   dependencies:
     is-promise "^2.1.0"
+
+run-async@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
 run-parallel@^1.1.9:
   version "1.1.9"
@@ -6579,6 +9283,13 @@ rxjs@^6.6.0:
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
+
+rxjs@^7.5.4, rxjs@^7.5.5:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
+  dependencies:
+    tslib "^2.1.0"
 
 safe-array-concat@^1.1.2:
   version "1.1.2"
@@ -6600,6 +9311,16 @@ safe-array-concat@^1.1.3:
     get-intrinsic "^1.2.6"
     has-symbols "^1.1.0"
     isarray "^2.0.5"
+
+safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-buffer@>=5.1.0:
   version "5.2.0"
@@ -6632,7 +9353,12 @@ safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
-"safer-buffer@>= 2.1.2 < 3":
+safe-stable-stringify@^2.3.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
+  integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
+
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -6679,6 +9405,40 @@ semver@^6.1.2, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
+semver@^7.0.0, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2, semver@^7.5.4:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
+
+send@~0.19.0, send@~0.19.1:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.19.2.tgz#59bc0da1b4ea7ad42736fd642b1c4294e114ff29"
+  integrity sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==
+  dependencies:
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    encodeurl "~2.0.0"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "~0.5.2"
+    http-errors "~2.0.1"
+    mime "1.6.0"
+    ms "2.1.3"
+    on-finished "~2.4.1"
+    range-parser "~1.2.1"
+    statuses "~2.0.2"
+
+serve-static@~1.16.2:
+  version "1.16.3"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.16.3.tgz#a97b74d955778583f3862a4f0b841eb4d5d78cf9"
+  integrity sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==
+  dependencies:
+    encodeurl "~2.0.0"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "~0.19.1"
+
 set-function-length@^1.2.1, set-function-length@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
@@ -6709,6 +9469,11 @@ set-proto@^1.0.0:
     dunder-proto "^1.0.1"
     es-errors "^1.3.0"
     es-object-atoms "^1.0.0"
+
+setprototypeof@1.2.0, setprototypeof@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 shallow-equal@^1.2.1:
   version "1.2.1"
@@ -6756,6 +9521,14 @@ side-channel-list@^1.0.0:
     es-errors "^1.3.0"
     object-inspect "^1.13.3"
 
+side-channel-list@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.1.tgz#c2e0b5a14a540aebee3bbc6c3f8666cc9b509127"
+  integrity sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.4"
+
 side-channel-map@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/side-channel-map/-/side-channel-map-1.0.1.tgz#d6bb6b37902c6fef5174e5f533fab4c732a26f42"
@@ -6798,10 +9571,26 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+side-channel@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.1.tgz#ea02c62e05dc4bea67d4442f0fb71ee192f8e0ab"
+  integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.4"
+    side-channel-list "^1.0.1"
+    side-channel-map "^1.0.1"
+    side-channel-weakmap "^1.0.2"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 simple-swizzle@^0.2.2:
   version "0.2.4"
@@ -6809,6 +9598,13 @@ simple-swizzle@^0.2.2:
   integrity sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==
   dependencies:
     is-arrayish "^0.3.1"
+
+skin-tone@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/skin-tone/-/skin-tone-2.0.0.tgz#4e3933ab45c0d4f4f781745d64b9f4c208e41237"
+  integrity sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==
+  dependencies:
+    unicode-emoji-modifier-base "^1.0.0"
 
 slash@^3.0.0:
   version "3.0.0"
@@ -6823,6 +9619,33 @@ slice-ansi@^2.1.0:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
+
+smart-buffer@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
+  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
+
+socks-proxy-agent@^8.0.3, socks-proxy-agent@^8.0.5:
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz#b9cdb4e7e998509d7659d689ce7697ac21645bee"
+  integrity sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "^4.3.4"
+    socks "^2.8.3"
+
+socks@^2.8.3:
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.9.tgz#aa5f130ca0f88a43fa44faf4869c50d22aa27752"
+  integrity sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==
+  dependencies:
+    ip-address "^10.1.1"
+    smart-buffer "^4.2.0"
+
+sort-any@^4.0.0:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/sort-any/-/sort-any-4.0.7.tgz#8e348cfe00af4708b63cea10a34c57170438d265"
+  integrity sha512-UuZVEXClHW+bVa6ZBQ4biTWmLXMP7y6/jv5arfA0rKk7ZExy+5Zm19uekIqqDx6ZuvUMu7z5Ba9FfBi6FlGXPQ==
 
 source-map-js@^1.2.1:
   version "1.2.1"
@@ -6845,15 +9668,50 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@^0.6.1:
+source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+split2@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
+  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
+sql-formatter@^15.3.0:
+  version "15.8.2"
+  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-15.8.2.tgz#ac0684864b3ac850e455dc915adbca78dd51aeb8"
+  integrity sha512-kTYRg5FIcvsDtYUG2Qn9pYT6xKwiLJN5TTIvc5Mur6hIg4pSfdpHu8Yyu5bqESLHnVM3mXzD446cb2+uEaKZXg==
+  dependencies:
+    argparse "^2.0.1"
+    nearley "^2.20.1"
+
+ssri@^10.0.0:
+  version "10.0.6"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-10.0.6.tgz#a8aade2de60ba2bce8688e3fa349bad05c7dc1e5"
+  integrity sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==
+  dependencies:
+    minipass "^7.0.3"
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==
+
+statuses@~1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+statuses@~2.0.1, statuses@~2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
 
 stop-iteration-iterator@^1.1.0:
   version "1.1.0"
@@ -6862,6 +9720,49 @@ stop-iteration-iterator@^1.1.0:
   dependencies:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
+
+stream-chain@^2.2.4, stream-chain@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/stream-chain/-/stream-chain-2.2.5.tgz#b30967e8f14ee033c5b9a19bbe8a2cba90ba0d09"
+  integrity sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==
+
+stream-events@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/stream-events/-/stream-events-1.0.5.tgz#bbc898ec4df33a4902d892333d47da9bf1c406d5"
+  integrity sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==
+  dependencies:
+    stubs "^3.0.0"
+
+stream-json@^1.7.3:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-1.9.1.tgz#e3fec03e984a503718946c170db7d74556c2a187"
+  integrity sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==
+  dependencies:
+    stream-chain "^2.2.5"
+
+stream-shift@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.3.tgz#85b8fab4d71010fc3ba8772e8046cc49b8a3864b"
+  integrity sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==
+
+streamx@^2.12.5, streamx@^2.15.0, streamx@^2.25.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.28.0.tgz#035ab56057b7ed2211b51d532e6973f0f99fbf11"
+  integrity sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==
+  dependencies:
+    events-universal "^1.0.0"
+    fast-fifo "^1.3.2"
+    text-decoder "^1.1.0"
+
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  name string-width-cjs
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^3.0.0:
   version "3.1.0"
@@ -6881,14 +9782,14 @@ string-width@^4.0.0, string-width@^4.1.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
   dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
 
 string.prototype.includes@^2.0.1:
   version "2.0.1"
@@ -6977,6 +9878,28 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
+string_decoder@^1.1.1, string_decoder@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+  name strip-ansi-cjs
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
@@ -6991,12 +9914,12 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+strip-ansi@^7.0.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
   dependencies:
-    ansi-regex "^5.0.1"
+    ansi-regex "^6.2.2"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -7030,10 +9953,40 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+stubs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stubs/-/stubs-3.0.0.tgz#e8d2ba1fa9c90570303c030b6900f7d5f89abe5b"
+  integrity sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==
+
 style-mod@^4.0.0, style-mod@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.1.3.tgz#6e9012255bb799bdac37e288f7671b5d71bf9f73"
   integrity sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==
+
+superstatic@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/superstatic/-/superstatic-9.2.0.tgz#c3d338e87fb1b695670c79db5affb18288441c32"
+  integrity sha512-QrJAJIpAij0jJT1nEwYTB0SzDi4k0wYygu6GxK0ko8twiQgfgaOAZ7Hu99p02MTAsGho753zhzSvsw8We4PBEQ==
+  dependencies:
+    basic-auth-connect "^1.1.0"
+    commander "^10.0.0"
+    compression "^1.7.0"
+    connect "^3.7.0"
+    destroy "^1.0.4"
+    glob-slasher "^1.0.1"
+    is-url "^1.2.2"
+    join-path "^1.1.1"
+    lodash "^4.17.19"
+    mime-types "^2.1.35"
+    minimatch "^6.1.6"
+    morgan "^1.8.2"
+    on-finished "^2.2.0"
+    on-headers "^1.0.0"
+    path-to-regexp "^1.9.0"
+    router "^2.0.0"
+    update-notifier-cjs "^5.1.6"
+  optionalDependencies:
+    re2 "^1.17.7"
 
 supports-color@7.1.0, supports-color@^7.1.0:
   version "7.1.0"
@@ -7048,6 +10001,21 @@ supports-color@^5.3.0, supports-color@^5.4.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-hyperlinks@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz#b8e485b179681dea496a1e7abdf8985bd3145461"
+  integrity sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
@@ -7093,51 +10061,70 @@ tailwindcss-animate@^1.0.7:
   resolved "https://registry.yarnpkg.com/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz#318b692c4c42676cc9e67b19b78775742388bef4"
   integrity sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==
 
-"tailwindcss@npm:@tailwindcss/postcss7-compat":
-  version "2.2.17"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/postcss7-compat/-/postcss7-compat-2.2.17.tgz#dc78f3880a2af84163150ff426a39e42b9ae8922"
-  integrity sha512-3h2svqQAqYHxRZ1KjsJjZOVTQ04m29LjfrLjXyZZEJuvUuJN+BCIF9GI8vhE1s0plS0mogd6E6YLg6mu4Wv/Vw==
+tar-stream@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-3.2.0.tgz#0d0064d9b67ea3c9f5abde155e35faab0df37591"
+  integrity sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==
   dependencies:
-    arg "^5.0.1"
-    autoprefixer "^9"
-    bytes "^3.0.0"
-    chalk "^4.1.2"
-    chokidar "^3.5.2"
-    color "^4.0.1"
-    cosmiconfig "^7.0.1"
-    detective "^5.2.0"
-    didyoumean "^1.2.2"
-    dlv "^1.1.3"
-    fast-glob "^3.2.7"
-    fs-extra "^10.0.0"
-    glob-parent "^6.0.1"
-    html-tags "^3.1.0"
-    is-color-stop "^1.1.0"
-    is-glob "^4.0.1"
-    lodash "^4.17.21"
-    lodash.topath "^4.5.2"
-    modern-normalize "^1.1.0"
-    node-emoji "^1.11.0"
-    normalize-path "^3.0.0"
-    object-hash "^2.2.0"
-    postcss "^7"
-    postcss-functions "^3"
-    postcss-js "^2"
-    postcss-load-config "^3.1.0"
-    postcss-nested "^4"
-    postcss-selector-parser "^6.0.6"
-    postcss-value-parser "^4.1.0"
-    pretty-hrtime "^1.0.3"
-    purgecss "^4.0.3"
-    quick-lru "^5.1.1"
-    reduce-css-calc "^2.1.8"
-    resolve "^1.20.0"
-    tmp "^0.2.1"
+    b4a "^1.6.4"
+    bare-fs "^4.5.5"
+    fast-fifo "^1.2.0"
+    streamx "^2.15.0"
+
+tar@^6.1.11, tar@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
+  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^5.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
+tcp-port-used@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tcp-port-used/-/tcp-port-used-1.0.3.tgz#fa609c94a7c930e334dbed59010f87ff00d32146"
+  integrity sha512-4CEQ3qRJYo+mtEbJ+OoQu3dF4TDkwaO3RDVC4UzP5cpAOIUWwuwPjD7sdxDFFqsMUjsXVVYBMlg/boAaloThMA==
+  dependencies:
+    debug "4.3.1"
+    is2 "2.0.1"
+
+teeny-request@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-9.0.0.tgz#18140de2eb6595771b1b02203312dfad79a4716d"
+  integrity sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==
+  dependencies:
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.0"
+    node-fetch "^2.6.9"
+    stream-events "^1.0.5"
+    uuid "^9.0.0"
+
+teex@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/teex/-/teex-1.0.1.tgz#b8fa7245ef8e8effa8078281946c85ab780a0b12"
+  integrity sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==
+  dependencies:
+    streamx "^2.12.5"
 
 term-size@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.0.tgz#1f16adedfe9bdc18800e1776821734086fcc6753"
   integrity sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==
+
+text-decoder@^1.1.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/text-decoder/-/text-decoder-1.2.7.tgz#5d073a9a74b9c0a9d28dfadcab96b604af57d8ba"
+  integrity sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==
+  dependencies:
+    b4a "^1.6.4"
+
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
 
 text-segmentation@^1.0.3:
   version "1.0.3"
@@ -7150,6 +10137,28 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
+
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  integrity sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
+  dependencies:
+    any-promise "^1.0.0"
+
+through2@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
+  dependencies:
+    readable-stream "~2.3.6"
+    xtend "~4.0.1"
 
 through@^2.3.6:
   version "2.3.8"
@@ -7183,6 +10192,11 @@ tmp@^0.2.1:
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
   integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
 
+tmp@^0.2.3:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
+  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
+
 to-readable-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
@@ -7200,10 +10214,32 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+toidentifier@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
 toposort@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
   integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
+
+toxic@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toxic/-/toxic-1.0.1.tgz#8c2e2528da591100adc3883f2c0e56acfb1c7288"
+  integrity sha512-WI3rIGdcaKULYg7KVoB0zcjikqvcYYvcuT6D89bFPz2rVR0Rl0PK6x8/X62rtdLtBKIE985NzVf/auTtGegIIg==
+  dependencies:
+    lodash "^4.17.10"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
+triple-beam@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.4.1.tgz#6fde70271dc6e5d73ca0c3b24e2d92afb7441984"
+  integrity sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==
 
 tsconfig-paths@^3.15.0:
   version "3.15.0"
@@ -7225,7 +10261,7 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
-tslib@^2.0.0, tslib@^2.8.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -7234,6 +10270,11 @@ tslib@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tsscmp@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
+  integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -7247,10 +10288,28 @@ type-fest@^0.10.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.10.0.tgz#7f06b2b9fbfc581068d1341ffabd0349ceafc642"
   integrity sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==
 
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
 type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-is@~1.6.18:
+  version "1.6.18"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.24"
 
 typed-array-buffer@^1.0.2:
   version "1.0.2"
@@ -7383,12 +10442,39 @@ undici@6.19.7:
   resolved "https://registry.yarnpkg.com/undici/-/undici-6.19.7.tgz#7d4cf26dc689838aa8b6753a3c5c4288fc1e0216"
   integrity sha512-HR3W/bMGPSr90i8AAp2C4DM3wChFdJPLrWYpIS++LxS8K+W535qftjt+4MyjNYHeWabMj1nvtmLIi7l++iq91A==
 
+unicode-emoji-modifier-base@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz#dbbd5b54ba30f287e2a8d5a249da6c0cef369459"
+  integrity sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==
+
+unique-filename@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-3.0.0.tgz#48ba7a5a16849f5080d26c760c86cf5cf05770ea"
+  integrity sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==
+  dependencies:
+    unique-slug "^4.0.0"
+
+unique-slug@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-4.0.0.tgz#6bae6bb16be91351badd24cdce741f892a6532e3"
+  integrity sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==
+  dependencies:
+    imurmurhash "^0.1.4"
+
 unique-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
   dependencies:
     crypto-random-string "^2.0.0"
+
+universal-analytics@0.5.3, universal-analytics@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/universal-analytics/-/universal-analytics-0.5.3.tgz#ff2d9b850062cdd4a8f652448047982a183c8e96"
+  integrity sha512-HXSMyIcf2XTvwZ6ZZQLfxfViRm/yTGoRgDeTbojtq6rezeyKB0sTBcKH2fhddnteAHRcHiKgr/ACpbgjGOC6RQ==
+  dependencies:
+    debug "^4.3.1"
+    uuid "^8.0.0"
 
 universal-user-agent@^4.0.0:
   version "4.0.1"
@@ -7409,6 +10495,11 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
+unpipe@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+  integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
+
 update-browserslist-db@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz#97e9c96ab0ae7bcac08e9ae5151d26e6bc6b5580"
@@ -7424,6 +10515,28 @@ update-browserslist-db@^1.1.4:
   dependencies:
     escalade "^3.2.0"
     picocolors "^1.1.1"
+
+update-notifier-cjs@^5.1.6:
+  version "5.1.7"
+  resolved "https://registry.yarnpkg.com/update-notifier-cjs/-/update-notifier-cjs-5.1.7.tgz#995733b43bdaeb136b999d55061fc385ef787a7f"
+  integrity sha512-eZWTh8F+VCEoC4UIh0pKmh8h4izj65VvLhCpJpVefUxdYe0fU3GBrC4Sbh1AoWA/miNPAb6UVlp2fUQNsfp+3g==
+  dependencies:
+    boxen "^5.0.0"
+    chalk "^4.1.0"
+    configstore "^5.0.1"
+    has-yarn "^2.1.0"
+    import-lazy "^2.1.0"
+    is-ci "^2.0.0"
+    is-installed-globally "^0.4.0"
+    is-npm "^5.0.0"
+    is-yarn-global "^0.3.0"
+    isomorphic-fetch "^3.0.0"
+    pupa "^2.1.1"
+    registry-auth-token "^5.0.1"
+    registry-url "^5.1.0"
+    semver "^7.3.7"
+    semver-diff "^3.1.1"
+    xdg-basedir "^4.0.0"
 
 update-notifier@4.1.0:
   version "4.1.0"
@@ -7456,6 +10569,11 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
+url-join@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-0.0.1.tgz#1db48ad422d3402469a87f7d97bdebfe4fb1e3c8"
+  integrity sha512-H6dnQ/yPAAVzMQRvEvyz01hhfQL5qRWSEt7BX8t9DqnPw9BjMb64fjIRq76Uvf1hkHp+mTZvEVJ5guXOT0Xqaw==
+
 url-join@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
@@ -7467,6 +10585,11 @@ url-parse-lax@^3.0.0:
   integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
   dependencies:
     prepend-http "^2.0.0"
+
+url-template@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
+  integrity sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==
 
 use-callback-ref@^1.3.3:
   version "1.3.3"
@@ -7493,10 +10616,15 @@ use-sync-external-store@^1.5.0:
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
   integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
-util-deprecate@^1.0.2:
+util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+utils-merge@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
+  integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
 utrie@^1.0.2:
   version "1.0.2"
@@ -7510,15 +10638,35 @@ uuid@7.0.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.2.tgz#7ff5c203467e91f5e0d85cfcbaaf7d2ebbca9be6"
   integrity sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==
 
+uuid@^8.0.0, uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.0, uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
 v8-compile-cache@^2.0.3:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz#cdada8bec61e15865f05d097c5f4fd30e94dc128"
   integrity sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==
 
+valid-url@^1:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
+  integrity sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==
+
 value-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
   integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
+
+vary@^1, vary@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+  integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
 vite@^6.0.9:
   version "6.0.9"
@@ -7555,6 +10703,16 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+web-streams-polyfill@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 websocket-driver@>=0.5.1:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.3.tgz#a2d4e0d4f4f116f1e6297eba58b05d430100e9f9"
@@ -7573,6 +10731,19 @@ whatwg-fetch@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+
+whatwg-fetch@^3.4.1:
+  version "3.6.20"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz#580ce6d791facec91d37c72890995a0b48d31c70"
+  integrity sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
@@ -7663,6 +10834,13 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
+which@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-4.0.0.tgz#cd60b5e74503a3fbcfbf6cd6b4138a8bae644c1a"
+  integrity sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==
+  dependencies:
+    isexe "^3.1.1"
+
 widest-line@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-3.1.0.tgz#8292333bbf66cb45ff0de1603b136b7ae1496eca"
@@ -7685,12 +10863,39 @@ windows-release@^3.1.0:
   dependencies:
     execa "^1.0.0"
 
+winston-transport@^4.4.0, winston-transport@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.9.0.tgz#3bba345de10297654ea6f33519424560003b3bf9"
+  integrity sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==
+  dependencies:
+    logform "^2.7.0"
+    readable-stream "^3.6.2"
+    triple-beam "^1.3.0"
+
+winston@^3.0.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.19.0.tgz#cc1d1262f5f45946904085cfffe73efb4b7a581d"
+  integrity sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==
+  dependencies:
+    "@colors/colors" "^1.6.0"
+    "@dabh/diagnostics" "^2.0.8"
+    async "^3.2.3"
+    is-stream "^2.0.0"
+    logform "^2.7.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    safe-stable-stringify "^2.3.1"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.9.0"
+
 word-wrap@~1.2.3:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7698,6 +10903,24 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+wrap-ansi@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"
@@ -7721,12 +10944,17 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
+ws@^7.5.10:
+  version "7.5.11"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.11.tgz#9460daf1812bb81a423c5b9eac746941a86310fa"
+  integrity sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==
+
 xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
 
-xtend@^4.0.2:
+xtend@^4.0.0, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
@@ -7741,6 +10969,11 @@ yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
 yaml@1.7.2, yaml@^1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.7.2.tgz#f26aabf738590ab61efaca502358e48dc9f348b2"
@@ -7753,6 +10986,11 @@ yaml@^1.10.0, yaml@^1.10.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@^2.2.1, yaml@^2.4.1:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
+
 yargs-parser@18.0.0:
   version "18.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.0.0.tgz#cb32a77e173f7ab758fe32b8a498b16433fc977e"
@@ -7761,10 +10999,28 @@ yargs-parser@18.0.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
 yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^16.0.0:
+  version "16.2.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.2.tgz#c56731dca0d2788ae0866dd3c83907d6bab85f7d"
+  integrity sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yargs@^17.7.2:
   version "17.7.2"
@@ -7779,6 +11035,11 @@ yargs@^17.7.2:
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
 
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
 yup@^0.28.1:
   version "0.28.1"
   resolved "https://registry.yarnpkg.com/yup/-/yup-0.28.1.tgz#60c0725be7057ed7a9ae61561333809332a63d47"
@@ -7791,3 +11052,12 @@ yup@^0.28.1:
     property-expr "^1.5.0"
     synchronous-promise "^2.0.6"
     toposort "^2.0.2"
+
+zip-stream@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-6.0.1.tgz#e141b930ed60ccaf5d7fa9c8260e0d1748a2bbfb"
+  integrity sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==
+  dependencies:
+    archiver-utils "^5.0.0"
+    compress-commons "^6.0.2"
+    readable-stream "^4.0.0"


### PR DESCRIPTION
## Summary

Reworks the session component's write path to use **Firestore-native optimistic writes**. Instead of read-modify-write cycles on the user document, `ModifyData` actions are translated into native Firestore atomic operations (`increment`, `arrayUnion`, `arrayRemove`, `delete`, targeted field-path updates) whenever the change can be expressed as one, falling back to a full rewrite only when it cannot. This lets Firestore's own conflict resolution reconcile concurrent and offline edits, and lets pending writes survive a reload.

## Architecture

The write path is split into focused, individually testable modules under `src/hooks/useFirebaseWithBridge/`:

- **`createChangeRuntime`** — orchestrator. Wires the writer, sequencer, and planner together; tracks the authenticated UID and current user-doc ref; (re)subscribes on auth/ID-token changes.
- **`mutationPlanner`** — validates a `ModifyData` action and classifies it into an update plan (delegating the translation to `modifyDataAdapter`).
- **`modifyDataAdapter`** — the core translation from `ModifyData` / JSONPointer actions into Firestore update operations. Handles canonical `Collection` wrappers (`order` membership + `valueById` map) with exact-match `arrayUnion`/`arrayRemove` membership transforms, and bails to a rewrite when a transform can't be expressed safely.
- **`mutationSentinels`** — provider-agnostic sentinel objects (`increment`/`delete`/`arrayUnion`/`arrayRemove`) emitted by the planner and converted to real `FieldValue` sentinels by the writer; also supports applying a plan to a plain doc (used by tests and rebasing).
- **`userDocSequencer`** — sequences writes against the user doc, tracks doc existence (unknown/exists/missing), rebases queued actions against fresh remote state, and restores the same-UID listener after an ID-token refresh / terminal error.
- **`firestoreChangeWriter`** — converts a plan into `docRef.update(...)` args, using `FieldPath` for keys containing Firestore metacharacters.

## Error-event semantics

The `onUserDataModificationError` event now fires only for changes submitted by the current page. After a reload, Firestore-restored pending writes reconcile without emitting the event. The event description in `pandasuite.json` (EN + FR) was updated accordingly.

## Testing

- **Unit tests** for every new module + expanded `modifyDataAdapter` coverage — 190 tests, all passing via `yarn test`.
- **Emulator conflict-contract tests** (`tests/emulator/`) exercising two-client conflicts, offline/online transitions, and stale deletes against the Firestore emulator via `yarn test:emulator` (requires the emulator).
- Adds a note on the Safari IndexedDB test workaround (`docs/testing/indexeddb-safari-workaround.md`).
